### PR TITLE
fix(migrations): resolve collation mismatch in 000032 anime_tags populate

### DIFF
--- a/db/migrations/000032_create_tags_table.up.sql
+++ b/db/migrations/000032_create_tags_table.up.sql
@@ -42,7 +42,10 @@ CROSS JOIN JSON_TABLE(
     a.genres,
     '$[*]' COLUMNS (genre VARCHAR(100) PATH '$')
 ) AS j
-INNER JOIN tags t ON t.name = TRIM(j.genre)
+-- Force a common collation on both sides: tags.name may be utf8mb4_general_ci
+-- (older DB default) while the JSON_TABLE-derived value is utf8mb4_0900_ai_ci
+-- (MySQL 8 default). Comparing them directly raises "Illegal mix of collations".
+INNER JOIN tags t ON t.name COLLATE utf8mb4_general_ci = TRIM(j.genre) COLLATE utf8mb4_general_ci
 WHERE a.genres IS NOT NULL
   AND JSON_VALID(a.genres)
   AND TRIM(j.genre) != '';


### PR DESCRIPTION
## Problem
The `anime-api-migration-1-40-1` job failed on staging with `Dirty database version 32`. Root cause: migration `000032_create_tags_table.up.sql` populates `anime_tags` with:
```sql
INNER JOIN tags t ON t.name = TRIM(j.genre)
```
`tags.name` is `utf8mb4_general_ci` (older DB default) but the `JSON_TABLE`-derived genre value is `utf8mb4_0900_ai_ci` (MySQL 8 default), so the comparison fails:
```
ERROR 1267 (HY000): Illegal mix of collations (utf8mb4_general_ci,IMPLICIT) and (utf8mb4_0900_ai_ci,IMPLICIT) for operation '='
```
The migration created `tags` (and populated it) but never populated `anime_tags`, leaving `schema_migrations` dirty at 32 — which blocks all further migrations and the deploy.

## Fix
Force both sides of the join to a common collation:
```sql
INNER JOIN tags t ON t.name COLLATE utf8mb4_general_ci = TRIM(j.genre) COLLATE utf8mb4_general_ci
```
Coercing **both** sides (not just one) makes it correct regardless of the environment's default collation.

## Staging already repaired
Staging's data was fixed by hand — `anime_tags` now holds **35,061 rows** and `schema_migrations` is clean at **32/0**, so staging is unblocked. This PR fixes the **migration file** so fresh environments and **prod** don't hit the same dirty-database failure when 1.40.1 deploys.

> Since migration 32 never applied cleanly via the tool anywhere (staging was hand-repaired), editing the file in place is safe — no environment has a tool-recorded clean apply of the old version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)