### PR TITLE
fix: wire streaming/schedule/air-time repositories into resolver

### DIFF
--- a/http/handlers/root_handler.go
+++ b/http/handlers/root_handler.go
@@ -15,8 +15,11 @@ import (
 	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_character"
 	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_character_staff_link"
 	anime3 "github.com/weeb-vip/anime-api/internal/db/repositories/anime_episode"
+	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_schedule"
 	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_season"
+	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_streaming_platform"
 	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_tag"
+	"github.com/weeb-vip/anime-api/internal/db/repositories/episode_air_time"
 	"github.com/weeb-vip/anime-api/internal/directives"
 	"github.com/weeb-vip/anime-api/internal/logger"
 	"github.com/weeb-vip/anime-api/internal/services/anime"
@@ -78,6 +81,9 @@ func BuildRootHandler(conf config.Config) http.Handler {
 	animeSeasonRepository := anime_season.NewAnimeSeasonRepository(database)
 	animeSeasonService := anime_season_service.NewAnimeSeasonService(animeSeasonRepository)
 	animeTagRepository := anime_tag.NewAnimeTagRepository(database)
+	animeScheduleRepository := anime_schedule.NewAnimeScheduleRepository(database)
+	animeStreamingPlatformRepository := anime_streaming_platform.NewAnimeStreamingPlatformRepository(database)
+	episodeAirTimeRepository := episode_air_time.NewEpisodeAirTimeRepository(database)
 	resolvers := &graph.Resolver{
 		Config:                             conf,
 		AnimeService:                       animeService,
@@ -86,6 +92,9 @@ func BuildRootHandler(conf config.Config) http.Handler {
 		AnimeCharacterWithStaffLinkService: animeCharacterWithStaffLinkService,
 		AnimeSeasonService:                 animeSeasonService,
 		AnimeTagRepository:                 animeTagRepository,
+		AnimeScheduleRepository:            animeScheduleRepository,
+		AnimeStreamingPlatformRepository:   animeStreamingPlatformRepository,
+		EpisodeAirTimeRepository:           episodeAirTimeRepository,
 	}
 
 	cfg := generated.Config{Resolvers: resolvers, Directives: directives.GetDirectives()}
@@ -140,6 +149,9 @@ func BuildRootHandlerWithContext(ctx context.Context, conf config.Config) http.H
 	animeSeasonRepository := anime_season.NewAnimeSeasonRepository(database)
 	animeSeasonService := anime_season_service.NewAnimeSeasonService(animeSeasonRepository)
 	animeTagRepository := anime_tag.NewAnimeTagRepository(database)
+	animeScheduleRepository := anime_schedule.NewAnimeScheduleRepository(database)
+	animeStreamingPlatformRepository := anime_streaming_platform.NewAnimeStreamingPlatformRepository(database)
+	episodeAirTimeRepository := episode_air_time.NewEpisodeAirTimeRepository(database)
 	resolvers := &graph.Resolver{
 		Config:                             conf,
 		AnimeService:                       animeService,
@@ -148,6 +160,9 @@ func BuildRootHandlerWithContext(ctx context.Context, conf config.Config) http.H
 		AnimeCharacterWithStaffLinkService: animeCharacterWithStaffLinkService,
 		AnimeSeasonService:                 animeSeasonService,
 		AnimeTagRepository:                 animeTagRepository,
+		AnimeScheduleRepository:            animeScheduleRepository,
+		AnimeStreamingPlatformRepository:   animeStreamingPlatformRepository,
+		EpisodeAirTimeRepository:           episodeAirTimeRepository,
 		CacheService:                       cacheService,
 		Context:                            ctx,
 	}


### PR DESCRIPTION
## Problem
The streaming-platforms feature shipped, rows are populated in prod (`anime_streaming_platform`, `anime_schedule`), but the GraphQL API returns **empty** `streamingPlatforms` / `scheduleInfo` for every anime — so the frontend shows nothing.

## Root cause
`Anime.StreamingPlatforms`, `Anime.ScheduleInfo`, and the air-time resolver each guard with:
```go
if r.AnimeStreamingPlatformRepository == nil { return nil, nil }
```
But **neither** `Resolver{}` construction in `http/handlers/root_handler.go` (`BuildRootHandler` and `BuildRootHandlerWithContext`) ever assigned `AnimeScheduleRepository`, `AnimeStreamingPlatformRepository`, or `EpisodeAirTimeRepository`. The fields defaulted to `nil`, so all three resolvers hit the guard and returned empty — the data was in the DB but never queried.

## Fix
Instantiate the three repositories and assign them in **both** constructors. No schema/resolver changes needed.

## Verified
- `go build ./http/handlers/...` passes.
- Both `Resolver{}` literals now carry all three repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)