### PR TITLE
fix: return slug from the season resolvers

### DIFF
--- a/internal/db/repositories/anime/anime_repository.go
+++ b/internal/db/repositories/anime/anime_repository.go
@@ -1134,6 +1134,7 @@ func (a *AnimeRepository) FindBySeasonWithEpisodes(ctx context.Context, season s
 		AnidbID            *string    `gorm:"column:anidbid"`
 		TheTVDBID          *string    `gorm:"column:thetvdbid"`
 		Type               *RECORD_TYPE `gorm:"column:type"`
+		UrlSlug            *string    `gorm:"column:url_slug"`
 		TitleEn            *string    `gorm:"column:title_en"`
 		TitleJp            *string    `gorm:"column:title_jp"`
 		TitleRomaji        *string    `gorm:"column:title_romaji"`
@@ -1173,6 +1174,7 @@ func (a *AnimeRepository) FindBySeasonWithEpisodes(ctx context.Context, season s
 			a.id as anime_id,
 			a.anidbid,
 			a.thetvdbid,
+			a.url_slug,
 			a.type,
 			a.title_en,
 			a.title_jp,
@@ -1232,6 +1234,7 @@ func (a *AnimeRepository) FindBySeasonWithEpisodes(ctx context.Context, season s
 				AnidbID:       result.AnidbID,
 				TheTVDBID:     result.TheTVDBID,
 				Type:          result.Type,
+				UrlSlug:       result.UrlSlug,
 				TitleEn:       result.TitleEn,
 				TitleJp:       result.TitleJp,
 				TitleRomaji:   result.TitleRomaji,

--- a/internal/db/repositories/anime/field_selection.go
+++ b/internal/db/repositories/anime/field_selection.go
@@ -37,6 +37,10 @@ func (fs *FieldSelection) BuildSelectClause(tableName string) string {
 		"id":            "id",
 		"anidbid":       "anidbid",
 		"thetvdbid":     "thetvdbid",
+		// Unmapped fields are silently dropped from the SELECT, so a field
+		// missing here comes back null with no error anywhere -- which is how
+		// animeBySeasons served slug: null while every other resolver worked.
+		"slug":          "url_slug",
 		"titleEn":       "title_en",
 		"titleJp":       "title_jp",
 		"titleRomaji":   "title_romaji",


### PR DESCRIPTION
`animeBySeasons` returns `slug: null` while `topRatedAnime`, `currentlyAiring` and `anime(id:)` all return it correctly. Follow-up to #52, which missed two season-specific query paths.

```
animeBySeasons    ->  None None
topRatedAnime     ->  frieren-beyond-journey-s-end  re-zero-...-season-4
currentlyAiring   ->  red-river  re-zero-...-season-4
```

## Two omissions, same cause

The GraphQL mappers were fine — both already set `Slug`. The column never reached them:

1. **`field_selection.go`** — the season resolver narrows its `SELECT` to the columns the query actually requested, via a field→column map. `slug` wasn't in it, and unmapped fields are **dropped silently**, so `url_slug` was excluded with no error anywhere. This is the live path.
2. **`FindBySeasonWithEpisodes`** — builds its own explicit column list instead of `anime.*`, and `url_slug` was never added.

Both are the same class of bug: a hand-maintained list of columns that a new column has to be remembered into, failing quietly rather than loudly.

## How it surfaced

The homepage rendered `/anime/<slug>` links in Top Rated, Newest and Airing This Week, but `/anime/<uuid>` in the seasonal section — 37 slug hrefs and 14 uuid hrefs on one page. Both URLs resolve (`animeHref` falls back to the id, and `/anime/<id>` redirects to the slug), so nothing appeared broken; the seasonal section just quietly took a redirect on every click.

It also broke an e2e test in a genuinely confusing way: the test adds one anime, then picks a *different* one to test token refresh against, filtering by `!href.includes(addedSlug)`. With the same anime appearing under both forms, the filter matched the anime it had just added, and the assertion failed on a "Plan to Watch" button rather than anything resembling the real cause.

Verified with `go build` and `go vet`. Note `gofmt` reports this file and several neighbours as unformatted — that is pre-existing on `main` (confirmed by running gofmt against `origin/main`), so I have left it rather than bury this change in a reformat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)