### PR TITLE
feat: expose voice actors and their credits

### DIFF
--- a/graph/generated/generated.go
+++ b/graph/generated/generated.go
@@ -39,6 +39,7 @@ type Config struct {
 
 type ResolverRoot interface {
 	Anime() AnimeResolver
+	AnimeStaff() AnimeStaffResolver
 	ApiInfo() ApiInfoResolver
 	Entity() EntityResolver
 	Episode() EpisodeResolver
@@ -144,6 +145,7 @@ type ComplexityRoot struct {
 		ID         func(childComplexity int) int
 		Image      func(childComplexity int) int
 		Language   func(childComplexity int) int
+		Roles      func(childComplexity int) int
 		Summary    func(childComplexity int) int
 		UpdatedAt  func(childComplexity int) int
 	}
@@ -203,9 +205,15 @@ type ComplexityRoot struct {
 		EpisodesByAnimeID           func(childComplexity int, animeID string) int
 		MostPopularAnime            func(childComplexity int, limit *int) int
 		NewestAnime                 func(childComplexity int, limit *int) int
+		Staff                       func(childComplexity int, id string) int
 		TopRatedAnime               func(childComplexity int, limit *int) int
 		__resolve__service          func(childComplexity int) int
 		__resolve_entities          func(childComplexity int, representations []map[string]interface{}) int
+	}
+
+	StaffRole struct {
+		Anime     func(childComplexity int) int
+		Character func(childComplexity int) int
 	}
 
 	StreamingPlatform struct {
@@ -236,6 +244,9 @@ type AnimeResolver interface {
 
 	NextEpisode(ctx context.Context, obj *model.Anime) (*model.Episode, error)
 }
+type AnimeStaffResolver interface {
+	Roles(ctx context.Context, obj *model.AnimeStaff) ([]*model.StaffRole, error)
+}
 type ApiInfoResolver interface {
 	AnimeAPI(ctx context.Context, obj *model.APIInfo) (*model.AnimeAPI, error)
 }
@@ -261,6 +272,7 @@ type QueryResolver interface {
 	AnimeBySeasons(ctx context.Context, season string, limit *int) ([]*model.Anime, error)
 	AnimeBySeasonAndYear(ctx context.Context, seasonName string, year int, limit *int) ([]*model.Anime, error)
 	CharactersAndStaffByAnimeID(ctx context.Context, animeID string) ([]*model.CharacterWithStaff, error)
+	Staff(ctx context.Context, id string) (*model.AnimeStaff, error)
 }
 type UserAnimeResolver interface {
 	Anime(ctx context.Context, obj *model.UserAnime) (*model.Anime, error)
@@ -813,6 +825,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.AnimeStaff.Language(childComplexity), true
 
+	case "AnimeStaff.roles":
+		if e.complexity.AnimeStaff.Roles == nil {
+			break
+		}
+
+		return e.complexity.AnimeStaff.Roles(childComplexity), true
+
 	case "AnimeStaff.summary":
 		if e.complexity.AnimeStaff.Summary == nil {
 			break
@@ -1149,6 +1168,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.NewestAnime(childComplexity, args["limit"].(*int)), true
 
+	case "Query.staff":
+		if e.complexity.Query.Staff == nil {
+			break
+		}
+
+		args, err := ec.field_Query_staff_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.Staff(childComplexity, args["id"].(string)), true
+
 	case "Query.topRatedAnime":
 		if e.complexity.Query.TopRatedAnime == nil {
 			break
@@ -1179,6 +1210,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.__resolve_entities(childComplexity, args["representations"].([]map[string]interface{})), true
+
+	case "StaffRole.anime":
+		if e.complexity.StaffRole.Anime == nil {
+			break
+		}
+
+		return e.complexity.StaffRole.Anime(childComplexity), true
+
+	case "StaffRole.character":
+		if e.complexity.StaffRole.Character == nil {
+			break
+		}
+
+		return e.complexity.StaffRole.Character(childComplexity), true
 
 	case "StreamingPlatform.name":
 		if e.complexity.StreamingPlatform.Name == nil {
@@ -1382,6 +1427,8 @@ type Query {
     animeBySeasonAndYear(seasonName: String!, year: Int!, limit: Int): [Anime!]
     "characters and staff by anime ID"
     charactersAndStaffByAnimeId(animeId: ID!): [CharacterWithStaff!]
+    "Get a staff member (voice actor) by ID. Null when no staff member has that id."
+    staff(id: ID!): AnimeStaff
 }
 `, BuiltIn: false},
 	{Name: "../types.graphqls", Input: `# Season is now a string scalar that can accept any season format
@@ -1694,6 +1741,30 @@ type AnimeStaff {
 
     "the characters associated with the staff member"
     characters: [AnimeCharacter!]
+
+    """
+    Every credited role for this staff member, across every anime. Ordered by
+    the anime's start date, newest first, with undated anime last.
+
+    anime_character rows are scoped to a single anime, so one person voicing the
+    same character across several seasons appears here once per season -- that
+    is a credit each, not a duplicate.
+    """
+    roles: [StaffRole!] @goField(forceResolver: true)
+}
+
+"""
+One credit: a character a staff member played, and the anime they played it in.
+"""
+type StaffRole {
+    "The character performed"
+    character: AnimeCharacter!
+
+    """
+    The anime the character belongs to. Null when the character outlived its
+    anime row -- character deletes are not cascaded from the anime side.
+    """
+    anime: Anime
 }
 
 type CharacterWithStaff {
@@ -2070,6 +2141,21 @@ func (ec *executionContext) field_Query_newestAnime_args(ctx context.Context, ra
 		}
 	}
 	args["limit"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_staff_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+		arg0, err = ec.unmarshalNID2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["id"] = arg0
 	return args, nil
 }
 
@@ -4319,6 +4405,8 @@ func (ec *executionContext) fieldContext_AnimeCharacter_staff(ctx context.Contex
 				return ec.fieldContext_AnimeStaff_updatedAt(ctx, field)
 			case "characters":
 				return ec.fieldContext_AnimeStaff_characters(ctx, field)
+			case "roles":
+				return ec.fieldContext_AnimeStaff_roles(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type AnimeStaff", field.Name)
 		},
@@ -5534,6 +5622,53 @@ func (ec *executionContext) fieldContext_AnimeStaff_characters(ctx context.Conte
 	return fc, nil
 }
 
+func (ec *executionContext) _AnimeStaff_roles(ctx context.Context, field graphql.CollectedField, obj *model.AnimeStaff) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AnimeStaff_roles(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.AnimeStaff().Roles(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.StaffRole)
+	fc.Result = res
+	return ec.marshalOStaffRole2ᚕᚖgithubᚗcomᚋweebᚑvipᚋanimeᚑapiᚋgraphᚋmodelᚐStaffRoleᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AnimeStaff_roles(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AnimeStaff",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "character":
+				return ec.fieldContext_StaffRole_character(ctx, field)
+			case "anime":
+				return ec.fieldContext_StaffRole_anime(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type StaffRole", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _ApiInfo_animeApi(ctx context.Context, field graphql.CollectedField, obj *model.APIInfo) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_ApiInfo_animeApi(ctx, field)
 	if err != nil {
@@ -5768,6 +5903,8 @@ func (ec *executionContext) fieldContext_CharacterWithStaff_staff(ctx context.Co
 				return ec.fieldContext_AnimeStaff_updatedAt(ctx, field)
 			case "characters":
 				return ec.fieldContext_AnimeStaff_characters(ctx, field)
+			case "roles":
+				return ec.fieldContext_AnimeStaff_roles(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type AnimeStaff", field.Name)
 		},
@@ -8098,6 +8235,88 @@ func (ec *executionContext) fieldContext_Query_charactersAndStaffByAnimeId(ctx c
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_staff(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_staff(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Staff(rctx, fc.Args["id"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.AnimeStaff)
+	fc.Result = res
+	return ec.marshalOAnimeStaff2ᚖgithubᚗcomᚋweebᚑvipᚋanimeᚑapiᚋgraphᚋmodelᚐAnimeStaff(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_staff(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_AnimeStaff_id(ctx, field)
+			case "givenName":
+				return ec.fieldContext_AnimeStaff_givenName(ctx, field)
+			case "language":
+				return ec.fieldContext_AnimeStaff_language(ctx, field)
+			case "familyName":
+				return ec.fieldContext_AnimeStaff_familyName(ctx, field)
+			case "image":
+				return ec.fieldContext_AnimeStaff_image(ctx, field)
+			case "birthday":
+				return ec.fieldContext_AnimeStaff_birthday(ctx, field)
+			case "birthPlace":
+				return ec.fieldContext_AnimeStaff_birthPlace(ctx, field)
+			case "bloodType":
+				return ec.fieldContext_AnimeStaff_bloodType(ctx, field)
+			case "hobbies":
+				return ec.fieldContext_AnimeStaff_hobbies(ctx, field)
+			case "summary":
+				return ec.fieldContext_AnimeStaff_summary(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_AnimeStaff_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_AnimeStaff_updatedAt(ctx, field)
+			case "characters":
+				return ec.fieldContext_AnimeStaff_characters(ctx, field)
+			case "roles":
+				return ec.fieldContext_AnimeStaff_roles(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AnimeStaff", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_staff_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query__entities(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query__entities(ctx, field)
 	if err != nil {
@@ -8325,6 +8544,193 @@ func (ec *executionContext) fieldContext_Query___schema(ctx context.Context, fie
 				return ec.fieldContext___Schema_directives(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type __Schema", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _StaffRole_character(ctx context.Context, field graphql.CollectedField, obj *model.StaffRole) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_StaffRole_character(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Character, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.AnimeCharacter)
+	fc.Result = res
+	return ec.marshalNAnimeCharacter2ᚖgithubᚗcomᚋweebᚑvipᚋanimeᚑapiᚋgraphᚋmodelᚐAnimeCharacter(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_StaffRole_character(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "StaffRole",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_AnimeCharacter_id(ctx, field)
+			case "animeId":
+				return ec.fieldContext_AnimeCharacter_animeId(ctx, field)
+			case "name":
+				return ec.fieldContext_AnimeCharacter_name(ctx, field)
+			case "role":
+				return ec.fieldContext_AnimeCharacter_role(ctx, field)
+			case "birthday":
+				return ec.fieldContext_AnimeCharacter_birthday(ctx, field)
+			case "zodiac":
+				return ec.fieldContext_AnimeCharacter_zodiac(ctx, field)
+			case "gender":
+				return ec.fieldContext_AnimeCharacter_gender(ctx, field)
+			case "race":
+				return ec.fieldContext_AnimeCharacter_race(ctx, field)
+			case "height":
+				return ec.fieldContext_AnimeCharacter_height(ctx, field)
+			case "weight":
+				return ec.fieldContext_AnimeCharacter_weight(ctx, field)
+			case "title":
+				return ec.fieldContext_AnimeCharacter_title(ctx, field)
+			case "martialStatus":
+				return ec.fieldContext_AnimeCharacter_martialStatus(ctx, field)
+			case "summary":
+				return ec.fieldContext_AnimeCharacter_summary(ctx, field)
+			case "image":
+				return ec.fieldContext_AnimeCharacter_image(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_AnimeCharacter_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_AnimeCharacter_updatedAt(ctx, field)
+			case "staff":
+				return ec.fieldContext_AnimeCharacter_staff(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AnimeCharacter", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _StaffRole_anime(ctx context.Context, field graphql.CollectedField, obj *model.StaffRole) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_StaffRole_anime(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Anime, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Anime)
+	fc.Result = res
+	return ec.marshalOAnime2ᚖgithubᚗcomᚋweebᚑvipᚋanimeᚑapiᚋgraphᚋmodelᚐAnime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_StaffRole_anime(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "StaffRole",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Anime_id(ctx, field)
+			case "anidbid":
+				return ec.fieldContext_Anime_anidbid(ctx, field)
+			case "thetvdbid":
+				return ec.fieldContext_Anime_thetvdbid(ctx, field)
+			case "slug":
+				return ec.fieldContext_Anime_slug(ctx, field)
+			case "titleEn":
+				return ec.fieldContext_Anime_titleEn(ctx, field)
+			case "titleJp":
+				return ec.fieldContext_Anime_titleJp(ctx, field)
+			case "titleRomaji":
+				return ec.fieldContext_Anime_titleRomaji(ctx, field)
+			case "titleKanji":
+				return ec.fieldContext_Anime_titleKanji(ctx, field)
+			case "titleSynonyms":
+				return ec.fieldContext_Anime_titleSynonyms(ctx, field)
+			case "description":
+				return ec.fieldContext_Anime_description(ctx, field)
+			case "imageUrl":
+				return ec.fieldContext_Anime_imageUrl(ctx, field)
+			case "tags":
+				return ec.fieldContext_Anime_tags(ctx, field)
+			case "studios":
+				return ec.fieldContext_Anime_studios(ctx, field)
+			case "animeStatus":
+				return ec.fieldContext_Anime_animeStatus(ctx, field)
+			case "episodeCount":
+				return ec.fieldContext_Anime_episodeCount(ctx, field)
+			case "episodes":
+				return ec.fieldContext_Anime_episodes(ctx, field)
+			case "duration":
+				return ec.fieldContext_Anime_duration(ctx, field)
+			case "rating":
+				return ec.fieldContext_Anime_rating(ctx, field)
+			case "startDate":
+				return ec.fieldContext_Anime_startDate(ctx, field)
+			case "endDate":
+				return ec.fieldContext_Anime_endDate(ctx, field)
+			case "broadcast":
+				return ec.fieldContext_Anime_broadcast(ctx, field)
+			case "source":
+				return ec.fieldContext_Anime_source(ctx, field)
+			case "licensors":
+				return ec.fieldContext_Anime_licensors(ctx, field)
+			case "ranking":
+				return ec.fieldContext_Anime_ranking(ctx, field)
+			case "malId":
+				return ec.fieldContext_Anime_malId(ctx, field)
+			case "scheduleInfo":
+				return ec.fieldContext_Anime_scheduleInfo(ctx, field)
+			case "streamingPlatforms":
+				return ec.fieldContext_Anime_streamingPlatforms(ctx, field)
+			case "fanart":
+				return ec.fieldContext_Anime_fanart(ctx, field)
+			case "seasons":
+				return ec.fieldContext_Anime_seasons(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Anime_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Anime_updatedAt(ctx, field)
+			case "nextEpisode":
+				return ec.fieldContext_Anime_nextEpisode(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Anime", field.Name)
 		},
 	}
 	return fc, nil
@@ -11171,19 +11577,19 @@ func (ec *executionContext) _AnimeStaff(ctx context.Context, sel ast.SelectionSe
 		case "id":
 			out.Values[i] = ec._AnimeStaff_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "givenName":
 			out.Values[i] = ec._AnimeStaff_givenName(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "language":
 			out.Values[i] = ec._AnimeStaff_language(ctx, field, obj)
 		case "familyName":
 			out.Values[i] = ec._AnimeStaff_familyName(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "image":
 			out.Values[i] = ec._AnimeStaff_image(ctx, field, obj)
@@ -11203,6 +11609,39 @@ func (ec *executionContext) _AnimeStaff(ctx context.Context, sel ast.SelectionSe
 			out.Values[i] = ec._AnimeStaff_updatedAt(ctx, field, obj)
 		case "characters":
 			out.Values[i] = ec._AnimeStaff_characters(ctx, field, obj)
+		case "roles":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._AnimeStaff_roles(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -11913,6 +12352,25 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "staff":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_staff(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "_entities":
 			field := field
 
@@ -11965,6 +12423,47 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Query___schema(ctx, field)
 			})
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var staffRoleImplementors = []string{"StaffRole"}
+
+func (ec *executionContext) _StaffRole(ctx context.Context, sel ast.SelectionSet, obj *model.StaffRole) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, staffRoleImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("StaffRole")
+		case "character":
+			out.Values[i] = ec._StaffRole_character(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "anime":
+			out.Values[i] = ec._StaffRole_anime(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -12669,6 +13168,16 @@ func (ec *executionContext) marshalNSeason2string(ctx context.Context, sel ast.S
 	return res
 }
 
+func (ec *executionContext) marshalNStaffRole2ᚖgithubᚗcomᚋweebᚑvipᚋanimeᚑapiᚋgraphᚋmodelᚐStaffRole(ctx context.Context, sel ast.SelectionSet, v *model.StaffRole) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._StaffRole(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNStreamingPlatform2ᚖgithubᚗcomᚋweebᚑvipᚋanimeᚑapiᚋgraphᚋmodelᚐStreamingPlatform(ctx context.Context, sel ast.SelectionSet, v *model.StreamingPlatform) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -13288,6 +13797,13 @@ func (ec *executionContext) marshalOAnimeStaff2ᚕᚖgithubᚗcomᚋweebᚑvip�
 	return ret
 }
 
+func (ec *executionContext) marshalOAnimeStaff2ᚖgithubᚗcomᚋweebᚑvipᚋanimeᚑapiᚋgraphᚋmodelᚐAnimeStaff(ctx context.Context, sel ast.SelectionSet, v *model.AnimeStaff) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._AnimeStaff(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interface{}) (bool, error) {
 	res, err := graphql.UnmarshalBoolean(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -13531,6 +14047,53 @@ func (ec *executionContext) marshalOInt2ᚖint(ctx context.Context, sel ast.Sele
 	}
 	res := graphql.MarshalInt(*v)
 	return res
+}
+
+func (ec *executionContext) marshalOStaffRole2ᚕᚖgithubᚗcomᚋweebᚑvipᚋanimeᚑapiᚋgraphᚋmodelᚐStaffRoleᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.StaffRole) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNStaffRole2ᚖgithubᚗcomᚋweebᚑvipᚋanimeᚑapiᚋgraphᚋmodelᚐStaffRole(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) marshalOStreamingPlatform2ᚕᚖgithubᚗcomᚋweebᚑvipᚋanimeᚑapiᚋgraphᚋmodelᚐStreamingPlatformᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.StreamingPlatform) graphql.Marshaler {

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -202,6 +202,13 @@ type AnimeStaff struct {
 	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
 	// the characters associated with the staff member
 	Characters []*AnimeCharacter `json:"characters,omitempty"`
+	// Every credited role for this staff member, across every anime. Ordered by
+	// the anime's start date, newest first, with undated anime last.
+	//
+	// anime_character rows are scoped to a single anime, so one person voicing the
+	// same character across several seasons appears here once per season -- that
+	// is a credit each, not a duplicate.
+	Roles []*StaffRole `json:"roles,omitempty"`
 }
 
 type APIInfo struct {
@@ -266,6 +273,15 @@ type Fanart struct {
 	ID        string  `json:"id"`
 	ImageURL  string  `json:"imageUrl"`
 	SourceURL *string `json:"sourceUrl,omitempty"`
+}
+
+// One credit: a character a staff member played, and the anime they played it in.
+type StaffRole struct {
+	// The character performed
+	Character *AnimeCharacter `json:"character"`
+	// The anime the character belongs to. Null when the character outlived its
+	// anime row -- character deletes are not cascaded from the anime side.
+	Anime *Anime `json:"anime,omitempty"`
 }
 
 // Streaming platform where an anime is available

--- a/graph/resolver.go
+++ b/graph/resolver.go
@@ -14,6 +14,7 @@ import (
 	"github.com/weeb-vip/anime-api/internal/services/anime"
 	"github.com/weeb-vip/anime-api/internal/services/anime_character"
 	anime_character_staff_link2 "github.com/weeb-vip/anime-api/internal/services/anime_character_staff_link"
+	"github.com/weeb-vip/anime-api/internal/services/anime_staff"
 	"github.com/weeb-vip/anime-api/internal/services/anime_season"
 	"github.com/weeb-vip/anime-api/internal/services/episodes"
 )
@@ -36,6 +37,7 @@ type Resolver struct {
 	AnimeEpisodeService                episodes.AnimeEpisodeServiceImpl
 	AnimeCharacterService              anime_character.AnimeCharacterServiceImpl
 	AnimeCharacterWithStaffLinkService anime_character_staff_link2.AnimeCharacterStaffLinkImpl
+	AnimeStaffService                  anime_staff.AnimeStaffServiceImpl
 	AnimeSeasonService                 anime_season.AnimeSeasonServiceImpl
 	AnimeTagRepository                 anime_tag.AnimeTagRepositoryImpl
 	AnimeScheduleRepository            anime_schedule.AnimeScheduleRepositoryImpl

--- a/graph/schema.graphqls
+++ b/graph/schema.graphqls
@@ -31,4 +31,6 @@ type Query {
     animeBySeasonAndYear(seasonName: String!, year: Int!, limit: Int): [Anime!]
     "characters and staff by anime ID"
     charactersAndStaffByAnimeId(animeId: ID!): [CharacterWithStaff!]
+    "Get a staff member (voice actor) by ID. Null when no staff member has that id."
+    staff(id: ID!): AnimeStaff
 }

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -78,6 +78,11 @@ func (r *queryResolver) CharactersAndStaffByAnimeID(ctx context.Context, animeID
 	return resolvers.CharactersAndStaffByAnimeID(ctx, r.AnimeCharacterWithStaffLinkService, animeID)
 }
 
+// Staff is the resolver for the staff field.
+func (r *queryResolver) Staff(ctx context.Context, id string) (*model.AnimeStaff, error) {
+	return resolvers.StaffByID(ctx, r.AnimeStaffService, id)
+}
+
 // Query returns generated.QueryResolver implementation.
 func (r *Resolver) Query() generated.QueryResolver { return &queryResolver{r} }
 

--- a/graph/types.graphqls
+++ b/graph/types.graphqls
@@ -308,6 +308,30 @@ type AnimeStaff {
 
     "the characters associated with the staff member"
     characters: [AnimeCharacter!]
+
+    """
+    Every credited role for this staff member, across every anime. Ordered by
+    the anime's start date, newest first, with undated anime last.
+
+    anime_character rows are scoped to a single anime, so one person voicing the
+    same character across several seasons appears here once per season -- that
+    is a credit each, not a duplicate.
+    """
+    roles: [StaffRole!] @goField(forceResolver: true)
+}
+
+"""
+One credit: a character a staff member played, and the anime they played it in.
+"""
+type StaffRole {
+    "The character performed"
+    character: AnimeCharacter!
+
+    """
+    The anime the character belongs to. Null when the character outlived its
+    anime row -- character deletes are not cascaded from the anime side.
+    """
+    anime: Anime
 }
 
 type CharacterWithStaff {

--- a/graph/types.resolvers.go
+++ b/graph/types.resolvers.go
@@ -122,6 +122,11 @@ func (r *animeResolver) NextEpisode(ctx context.Context, obj *model.Anime) (*mod
 	return resolvers.NextEpisode(ctx, r.AnimeEpisodeService, animeID)
 }
 
+// Roles is the resolver for the roles field.
+func (r *animeStaffResolver) Roles(ctx context.Context, obj *model.AnimeStaff) ([]*model.StaffRole, error) {
+	return resolvers.RolesByStaffID(ctx, r.AnimeCharacterWithStaffLinkService, r.AnimeService, obj.ID)
+}
+
 // AnimeAPI is the resolver for the animeApi field.
 func (r *apiInfoResolver) AnimeAPI(ctx context.Context, obj *model.APIInfo) (*model.AnimeAPI, error) {
 	return resolvers.AnimeAPI(r.Config)
@@ -175,6 +180,9 @@ func (r *userAnimeResolver) Anime(ctx context.Context, obj *model.UserAnime) (*m
 // Anime returns generated.AnimeResolver implementation.
 func (r *Resolver) Anime() generated.AnimeResolver { return &animeResolver{r} }
 
+// AnimeStaff returns generated.AnimeStaffResolver implementation.
+func (r *Resolver) AnimeStaff() generated.AnimeStaffResolver { return &animeStaffResolver{r} }
+
 // ApiInfo returns generated.ApiInfoResolver implementation.
 func (r *Resolver) ApiInfo() generated.ApiInfoResolver { return &apiInfoResolver{r} }
 
@@ -185,6 +193,7 @@ func (r *Resolver) Episode() generated.EpisodeResolver { return &episodeResolver
 func (r *Resolver) UserAnime() generated.UserAnimeResolver { return &userAnimeResolver{r} }
 
 type animeResolver struct{ *Resolver }
+type animeStaffResolver struct{ *Resolver }
 type apiInfoResolver struct{ *Resolver }
 type episodeResolver struct{ *Resolver }
 type userAnimeResolver struct{ *Resolver }

--- a/http/handlers/root_handler.go
+++ b/http/handlers/root_handler.go
@@ -14,6 +14,7 @@ import (
 	anime2 "github.com/weeb-vip/anime-api/internal/db/repositories/anime"
 	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_character"
 	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_character_staff_link"
+	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_staff"
 	anime3 "github.com/weeb-vip/anime-api/internal/db/repositories/anime_episode"
 	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_schedule"
 	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_fanart"
@@ -26,6 +27,7 @@ import (
 	"github.com/weeb-vip/anime-api/internal/services/anime"
 	anime_character2 "github.com/weeb-vip/anime-api/internal/services/anime_character"
 	anime_character_staff_link2 "github.com/weeb-vip/anime-api/internal/services/anime_character_staff_link"
+	anime_staff2 "github.com/weeb-vip/anime-api/internal/services/anime_staff"
 	anime_season_service "github.com/weeb-vip/anime-api/internal/services/anime_season"
 	"github.com/weeb-vip/anime-api/internal/services/episodes"
 )
@@ -79,6 +81,8 @@ func BuildRootHandler(conf config.Config) http.Handler {
 	animeCharacterService := anime_character2.NewAnimeCharacterService(animeCharacterRepository)
 	animeCharacterWithStaffLinkRepository := anime_character_staff_link.NewAnimeCharacterStaffLinkRepository(database)
 	animeCharacterWithStaffLinkService := anime_character_staff_link2.NewAnimeCharacterStaffLinkService(animeCharacterWithStaffLinkRepository)
+	animeStaffRepository := anime_staff.NewAnimeStaffRepository(database)
+	animeStaffService := anime_staff2.NewAnimeStaffService(animeStaffRepository)
 	animeSeasonRepository := anime_season.NewAnimeSeasonRepository(database)
 	animeSeasonService := anime_season_service.NewAnimeSeasonService(animeSeasonRepository)
 	animeTagRepository := anime_tag.NewAnimeTagRepository(database)
@@ -92,6 +96,7 @@ func BuildRootHandler(conf config.Config) http.Handler {
 		AnimeEpisodeService:                animeEpisodeService,
 		AnimeCharacterService:              animeCharacterService,
 		AnimeCharacterWithStaffLinkService: animeCharacterWithStaffLinkService,
+		AnimeStaffService:                  animeStaffService,
 		AnimeSeasonService:                 animeSeasonService,
 		AnimeTagRepository:                 animeTagRepository,
 		AnimeScheduleRepository:            animeScheduleRepository,
@@ -149,6 +154,8 @@ func BuildRootHandlerWithContext(ctx context.Context, conf config.Config) http.H
 	animeCharacterService := anime_character2.NewAnimeCharacterService(animeCharacterRepository)
 	animeCharacterWithStaffLinkRepository := anime_character_staff_link.NewAnimeCharacterStaffLinkRepository(database)
 	animeCharacterWithStaffLinkService := anime_character_staff_link2.NewAnimeCharacterStaffLinkService(animeCharacterWithStaffLinkRepository)
+	animeStaffRepository := anime_staff.NewAnimeStaffRepository(database)
+	animeStaffService := anime_staff2.NewAnimeStaffService(animeStaffRepository)
 	animeSeasonRepository := anime_season.NewAnimeSeasonRepository(database)
 	animeSeasonService := anime_season_service.NewAnimeSeasonService(animeSeasonRepository)
 	animeTagRepository := anime_tag.NewAnimeTagRepository(database)
@@ -162,6 +169,7 @@ func BuildRootHandlerWithContext(ctx context.Context, conf config.Config) http.H
 		AnimeEpisodeService:                animeEpisodeService,
 		AnimeCharacterService:              animeCharacterService,
 		AnimeCharacterWithStaffLinkService: animeCharacterWithStaffLinkService,
+		AnimeStaffService:                  animeStaffService,
 		AnimeSeasonService:                 animeSeasonService,
 		AnimeTagRepository:                 animeTagRepository,
 		AnimeScheduleRepository:            animeScheduleRepository,

--- a/internal/db/repositories/anime_character_staff_link/anime_character_staff_link_repository.go
+++ b/internal/db/repositories/anime_character_staff_link/anime_character_staff_link_repository.go
@@ -22,6 +22,7 @@ func (AnimeCharacterWithStaff) TableName() string {
 
 type AnimeCharacterStaffLinkRepositoryImpl interface {
 	FindAnimeCharacterAndStaffByAnimeId(ctx context.Context, animeId string) ([]*AnimeCharacterWithStaff, error)
+	FindCharactersByStaffId(ctx context.Context, staffId string) ([]*anime_character.AnimeCharacter, error)
 }
 
 type AnimeCharacterStaffLinkRepository struct {
@@ -154,4 +155,51 @@ func (a *AnimeCharacterStaffLinkRepository) FindAnimeCharacterAndStaffByAnimeId(
 		Env:     metrics.GetCurrentEnv(),
 	})
 	return result, nil
+}
+
+
+// FindCharactersByStaffId returns every character this staff member is linked
+// to, across every anime.
+//
+// anime_staff is deduplicated on (given_name, family_name) by the scraper and
+// carries no anime_id, so one row is one real person and this join is the whole
+// of their credited work -- no cross-anime name matching needed.
+//
+// Ordered by the anime's start date, newest first. MySQL sorts NULL first on
+// ASC and last on DESC, so undated anime land at the end of the DESC ordering
+// on their own; the explicit IS NULL key keeps that true if the direction ever
+// changes.
+func (a *AnimeCharacterStaffLinkRepository) FindCharactersByStaffId(ctx context.Context, staffId string) ([]*anime_character.AnimeCharacter, error) {
+	startTime := time.Now()
+
+	var characters []*anime_character.AnimeCharacter
+
+	err := a.db.DB.WithContext(ctx).
+		Table("anime_character_staff_link").
+		Select("anime_character.*").
+		Joins("JOIN anime_character ON anime_character.id = anime_character_staff_link.character_id").
+		Joins("LEFT JOIN anime ON anime.id = anime_character.anime_id").
+		Where("anime_character_staff_link.staff_id = ?", staffId).
+		Order("anime.start_date IS NULL, anime.start_date DESC").
+		Find(&characters).Error
+
+	if err != nil {
+		_ = metrics.NewMetricsInstance().DatabaseMetric(float64(time.Since(startTime).Milliseconds()), metrics_lib.DatabaseMetricLabels{
+			Service: "anime-api",
+			Table:   "anime_character_staff_link",
+			Method:  metrics_lib.DatabaseMetricMethodSelect,
+			Result:  metrics_lib.Error,
+			Env:     metrics.GetCurrentEnv(),
+		})
+		return nil, err
+	}
+
+	_ = metrics.NewMetricsInstance().DatabaseMetric(float64(time.Since(startTime).Milliseconds()), metrics_lib.DatabaseMetricLabels{
+		Service: "anime-api",
+		Table:   "anime_character_staff_link",
+		Method:  metrics_lib.DatabaseMetricMethodSelect,
+		Result:  metrics_lib.Success,
+		Env:     metrics.GetCurrentEnv(),
+	})
+	return characters, nil
 }

--- a/internal/db/repositories/anime_staff/anime_staff_repository.go
+++ b/internal/db/repositories/anime_staff/anime_staff_repository.go
@@ -1,10 +1,16 @@
 package anime_staff
 
 import (
+	"context"
+	"time"
+
 	"github.com/weeb-vip/anime-api/internal/db"
+	"github.com/weeb-vip/anime-api/metrics"
+	metrics_lib "github.com/weeb-vip/go-metrics-lib"
 )
 
 type AnimeStaffRepositoryImpl interface {
+	FindStaffByID(ctx context.Context, id string) (*AnimeStaff, error)
 }
 
 type AnimeStaffRepository struct {
@@ -13,4 +19,30 @@ type AnimeStaffRepository struct {
 
 func NewAnimeStaffRepository(db *db.DB) AnimeStaffRepositoryImpl {
 	return &AnimeStaffRepository{db: db}
+}
+
+func (a *AnimeStaffRepository) FindStaffByID(ctx context.Context, id string) (*AnimeStaff, error) {
+	startTime := time.Now()
+
+	var staff AnimeStaff
+	err := a.db.DB.WithContext(ctx).Where("id = ?", id).First(&staff).Error
+	if err != nil {
+		_ = metrics.NewMetricsInstance().DatabaseMetric(float64(time.Since(startTime).Milliseconds()), metrics_lib.DatabaseMetricLabels{
+			Service: "anime-api",
+			Table:   "anime_staff",
+			Method:  metrics_lib.DatabaseMetricMethodSelect,
+			Result:  metrics_lib.Error,
+			Env:     metrics.GetCurrentEnv(),
+		})
+		return nil, err
+	}
+
+	_ = metrics.NewMetricsInstance().DatabaseMetric(float64(time.Since(startTime).Milliseconds()), metrics_lib.DatabaseMetricLabels{
+		Service: "anime-api",
+		Table:   "anime_staff",
+		Method:  metrics_lib.DatabaseMetricMethodSelect,
+		Result:  metrics_lib.Success,
+		Env:     metrics.GetCurrentEnv(),
+	})
+	return &staff, nil
 }

--- a/internal/resolvers/staff.go
+++ b/internal/resolvers/staff.go
@@ -1,0 +1,164 @@
+package resolvers
+
+import (
+	"context"
+	"errors"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"gorm.io/gorm"
+
+	"github.com/weeb-vip/anime-api/graph/model"
+	anime_character2 "github.com/weeb-vip/anime-api/internal/db/repositories/anime_character"
+	anime_staff2 "github.com/weeb-vip/anime-api/internal/db/repositories/anime_staff"
+	"github.com/weeb-vip/anime-api/internal/services/anime"
+	anime_character_staff_link2 "github.com/weeb-vip/anime-api/internal/services/anime_character_staff_link"
+	anime_staff3 "github.com/weeb-vip/anime-api/internal/services/anime_staff"
+	"github.com/weeb-vip/anime-api/tracing"
+)
+
+func transformStaffToGraphQL(staff anime_staff2.AnimeStaff) *model.AnimeStaff {
+	return &model.AnimeStaff{
+		ID:         staff.ID,
+		GivenName:  staff.GivenName,
+		FamilyName: staff.FamilyName,
+		Language:   &staff.Language,
+		Image:      &staff.Image,
+		Birthday:   &staff.Birthday,
+		BirthPlace: &staff.BirthPlace,
+		BloodType:  &staff.BloodType,
+		Hobbies:    &staff.Hobbies,
+		Summary:    &staff.Summary,
+		CreatedAt:  &staff.CreatedAt,
+		UpdatedAt:  &staff.UpdatedAt,
+	}
+}
+
+func transformCharacterToGraphQL(character anime_character2.AnimeCharacter) *model.AnimeCharacter {
+	return &model.AnimeCharacter{
+		ID:            character.ID,
+		AnimeID:       character.AnimeID,
+		Name:          character.Name,
+		Role:          character.Role,
+		Birthday:      &character.Birthday,
+		Zodiac:        &character.Zodiac,
+		Gender:        &character.Gender,
+		Race:          &character.Race,
+		Height:        &character.Height,
+		Weight:        &character.Weight,
+		Title:         &character.Title,
+		MartialStatus: &character.MartialStatus,
+		Summary:       &character.Summary,
+		Image:         &character.Image,
+		CreatedAt:     &character.CreatedAt,
+		UpdatedAt:     &character.UpdatedAt,
+	}
+}
+
+// StaffByID resolves the staff query. A missing staff member is a null result,
+// not an error -- the field is nullable so a stale link from an old page does
+// not fail the whole query.
+func StaffByID(ctx context.Context, staffService anime_staff3.AnimeStaffServiceImpl, id string) (*model.AnimeStaff, error) {
+	tracer := tracing.GetTracer(ctx)
+	ctx, span := tracer.Start(ctx, "StaffByID",
+		trace.WithAttributes(
+			attribute.String("staff.id", id),
+			attribute.String("resolver.name", "StaffByID"),
+		),
+		tracing.GetEnvironmentAttribute(),
+	)
+	defer span.End()
+
+	staff, err := staffService.StaffByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			span.SetAttributes(attribute.Bool("staff.found", false))
+			return nil, nil
+		}
+		span.RecordError(err)
+		return nil, err
+	}
+
+	return transformStaffToGraphQL(*staff), nil
+}
+
+// RolesByStaffID resolves AnimeStaff.roles: every character this person played,
+// each paired with the anime it was in.
+//
+// Two queries, not one per role: the characters come back in one join, then
+// their anime are fetched in a single batch by id. Prolific voice actors have
+// hundreds of credits, so a per-role anime lookup would be a few hundred round
+// trips for one page.
+func RolesByStaffID(
+	ctx context.Context,
+	linkService anime_character_staff_link2.AnimeCharacterStaffLinkImpl,
+	animeService anime.AnimeServiceImpl,
+	staffID string,
+) ([]*model.StaffRole, error) {
+	tracer := tracing.GetTracer(ctx)
+	ctx, span := tracer.Start(ctx, "RolesByStaffID",
+		trace.WithAttributes(
+			attribute.String("staff.id", staffID),
+			attribute.String("resolver.name", "RolesByStaffID"),
+		),
+		tracing.GetEnvironmentAttribute(),
+	)
+	defer span.End()
+
+	characters, err := linkService.FindCharactersByStaffId(ctx, staffID)
+	if err != nil {
+		span.RecordError(err)
+		return nil, err
+	}
+
+	span.SetAttributes(attribute.Int("staff.role_count", len(characters)))
+	if len(characters) == 0 {
+		return []*model.StaffRole{}, nil
+	}
+
+	animeIDs := make([]string, 0, len(characters))
+	seen := make(map[string]struct{}, len(characters))
+	for _, character := range characters {
+		if character.AnimeID == "" {
+			continue
+		}
+		if _, ok := seen[character.AnimeID]; ok {
+			continue
+		}
+		seen[character.AnimeID] = struct{}{}
+		animeIDs = append(animeIDs, character.AnimeID)
+	}
+
+	animeByID := make(map[string]*model.Anime, len(animeIDs))
+	if len(animeIDs) > 0 {
+		foundAnime, err := animeService.AnimeByIDs(ctx, animeIDs)
+		if err != nil {
+			span.RecordError(err)
+			return nil, err
+		}
+		for _, entity := range foundAnime {
+			if entity == nil {
+				continue
+			}
+			transformed, err := transformAnimeToGraphQL(*entity)
+			if err != nil {
+				span.RecordError(err)
+				return nil, err
+			}
+			animeByID[entity.ID] = transformed
+		}
+	}
+
+	roles := make([]*model.StaffRole, 0, len(characters))
+	for _, character := range characters {
+		if character == nil {
+			continue
+		}
+		roles = append(roles, &model.StaffRole{
+			Character: transformCharacterToGraphQL(*character),
+			Anime:     animeByID[character.AnimeID],
+		})
+	}
+
+	return roles, nil
+}

--- a/internal/services/anime_character_staff_link/anime_character_staff_link.go
+++ b/internal/services/anime_character_staff_link/anime_character_staff_link.go
@@ -2,11 +2,13 @@ package anime_character_staff_link
 
 import (
 	"context"
+	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_character"
 	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_character_staff_link"
 )
 
 type AnimeCharacterStaffLinkImpl interface {
 	FindAnimeCharacterAndStaffByAnimeId(ctx context.Context, animeId string) ([]*anime_character_staff_link.AnimeCharacterWithStaff, error)
+	FindCharactersByStaffId(ctx context.Context, staffId string) ([]*anime_character.AnimeCharacter, error)
 }
 
 type AnimeCharacterStaffLinkService struct {
@@ -25,4 +27,12 @@ func (a *AnimeCharacterStaffLinkService) FindAnimeCharacterAndStaffByAnimeId(ctx
 		return nil, err
 	}
 	return animeCharacters, nil
+}
+
+func (a *AnimeCharacterStaffLinkService) FindCharactersByStaffId(ctx context.Context, staffId string) ([]*anime_character.AnimeCharacter, error) {
+	characters, err := a.Repository.FindCharactersByStaffId(ctx, staffId)
+	if err != nil {
+		return nil, err
+	}
+	return characters, nil
 }

--- a/internal/services/anime_staff/anime_staff.go
+++ b/internal/services/anime_staff/anime_staff.go
@@ -1,0 +1,25 @@
+package anime_staff
+
+import (
+	"context"
+
+	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_staff"
+)
+
+type AnimeStaffServiceImpl interface {
+	StaffByID(ctx context.Context, id string) (*anime_staff.AnimeStaff, error)
+}
+
+type AnimeStaffService struct {
+	Repository anime_staff.AnimeStaffRepositoryImpl
+}
+
+func NewAnimeStaffService(repository anime_staff.AnimeStaffRepositoryImpl) AnimeStaffServiceImpl {
+	return &AnimeStaffService{
+		Repository: repository,
+	}
+}
+
+func (a *AnimeStaffService) StaffByID(ctx context.Context, id string) (*anime_staff.AnimeStaff, error) {
+	return a.Repository.FindStaffByID(ctx, id)
+}


### PR DESCRIPTION
## What

Two additive schema fields, so a voice actor page has something to read:

- `staff(id: ID!): AnimeStaff` — a voice actor by id, nullable
- `AnimeStaff.roles: [StaffRole!]` — every character they played, each paired with the anime it was in

```graphql
type StaffRole {
  character: AnimeCharacter!
  anime: Anime
}
```

## Why this needed no pipeline work

`anime_staff` is deduplicated on `(given_name, family_name)` by the scraper and carries no `anime_id`, so one row there is one real person, and `anime_character_staff_link` already joins them to every character they've voiced. The data was there — nothing read it. Staff were only reachable through `charactersAndStaffByAnimeId`, which answers "who is in this anime" and cannot answer "what else has this person been in".

## Shape notes

- **Two queries, not one per credit.** Characters come back in a single join, then their anime in one batch by id. Mary Elizabeth McGlynn has 117 credits across 90 anime; a per-role anime lookup would be ninety round trips for one page.
- **Ordered by the anime's start date, newest first**, undated last.
- **Repeat characters are repeat credits.** `anime_character` rows are scoped to one anime, so voicing Motoko Kusanagi across three SAC_2045 entries is three roles here. That is one credit each, not a duplicate.
- `StaffRole.anime` is nullable — character deletes are not cascaded from the anime side, so a character can outlive its anime row.

## Verified

Run against the staging database (port-forwarded, read-only), `staff` + `roles` returns 117 roles / 90 distinct anime for McGlynn, correctly ordered, zero null anime.

## Not addressed

`go vet ./...` fails in `internal/services` and `internal/resolvers` on two test files (`air_time_test.go`, `anime_season_optimized_test.go`) whose call signatures drifted in earlier refactors. Confirmed identical on `main` with this branch stashed — pre-existing, left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)