### PR TITLE
feat: relate anime that share a TheTVDB series id

### DIFF
--- a/graph/generated/generated.go
+++ b/graph/generated/generated.go
@@ -71,6 +71,7 @@ type ComplexityRoot struct {
 		NextEpisode        func(childComplexity int) int
 		Ranking            func(childComplexity int) int
 		Rating             func(childComplexity int) int
+		RelatedAnime       func(childComplexity int, limit *int) int
 		ScheduleInfo       func(childComplexity int) int
 		Seasons            func(childComplexity int) int
 		Slug               func(childComplexity int) int
@@ -85,6 +86,7 @@ type ComplexityRoot struct {
 		TitleKanji         func(childComplexity int) int
 		TitleRomaji        func(childComplexity int) int
 		TitleSynonyms      func(childComplexity int) int
+		Type               func(childComplexity int) int
 		UpdatedAt          func(childComplexity int) int
 	}
 
@@ -243,6 +245,8 @@ type AnimeResolver interface {
 	StreamingPlatforms(ctx context.Context, obj *model.Anime) ([]*model.StreamingPlatform, error)
 	Fanart(ctx context.Context, obj *model.Anime) ([]*model.Fanart, error)
 	Seasons(ctx context.Context, obj *model.Anime) ([]*model.AnimeSeason, error)
+
+	RelatedAnime(ctx context.Context, obj *model.Anime, limit *int) ([]*model.Anime, error)
 
 	NextEpisode(ctx context.Context, obj *model.Anime) (*model.Episode, error)
 }
@@ -415,6 +419,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Anime.Rating(childComplexity), true
 
+	case "Anime.relatedAnime":
+		if e.complexity.Anime.RelatedAnime == nil {
+			break
+		}
+
+		args, err := ec.field_Anime_relatedAnime_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Anime.RelatedAnime(childComplexity, args["limit"].(*int)), true
+
 	case "Anime.scheduleInfo":
 		if e.complexity.Anime.ScheduleInfo == nil {
 			break
@@ -512,6 +528,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Anime.TitleSynonyms(childComplexity), true
+
+	case "Anime.type":
+		if e.complexity.Anime.Type == nil {
+			break
+		}
+
+		return e.complexity.Anime.Type(childComplexity), true
 
 	case "Anime.updatedAt":
 		if e.complexity.Anime.UpdatedAt == nil {
@@ -1594,6 +1617,30 @@ type Anime @key(fields: "id") {
     fanart: [Fanart!] @goField(forceResolver: true)
     "Anime seasons"
     seasons: [AnimeSeason!] @goField(forceResolver: true)
+
+    """
+    Record type as the source classifies it -- TV, Movie, OVA, ONA, Special and
+    so on. Exposed because it is what separates a main entry from a side story
+    in relatedAnime, where a list of titles alone does not say which is which.
+    """
+    type: String
+
+    """
+    Other entries in the same series, oldest first, undated last.
+
+    Derived from a shared TheTVDB series id rather than from any relation the
+    sources state: TheTVDB gives one series id to a show and everything hanging
+    off it, so the seasons, OVAs and specials of one franchise share it. That
+    makes this an editorial grouping rather than an inference -- but also a
+    plain grouping, so it says these belong together and deliberately does not
+    claim which is a sequel and which is a side story. Read ` + "`" + `type` + "`" + ` and
+    ` + "`" + `startDate` + "`" + ` for that.
+
+    Empty for the anime that have no TheTVDB id, which is most of the
+    catalogue; callers should treat an empty list as "not known", not as
+    "stands alone".
+    """
+    relatedAnime(limit: Int): [Anime!] @goField(forceResolver: true)
     createdAt: String!
     updatedAt: String!
     nextEpisode: Episode @goField(forceResolver: true )
@@ -1896,6 +1943,21 @@ func (ec *executionContext) dir_scoped_args(ctx context.Context, rawArgs map[str
 		}
 	}
 	args["scope"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Anime_relatedAnime_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *int
+	if tmp, ok := rawArgs["limit"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("limit"))
+		arg0, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["limit"] = arg0
 	return args, nil
 }
 
@@ -3520,6 +3582,169 @@ func (ec *executionContext) fieldContext_Anime_seasons(ctx context.Context, fiel
 			}
 			return nil, fmt.Errorf("no field named %q was found under type AnimeSeason", field.Name)
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Anime_type(ctx context.Context, field graphql.CollectedField, obj *model.Anime) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Anime_type(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Type, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Anime_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Anime",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Anime_relatedAnime(ctx context.Context, field graphql.CollectedField, obj *model.Anime) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Anime_relatedAnime(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Anime().RelatedAnime(rctx, obj, fc.Args["limit"].(*int))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.Anime)
+	fc.Result = res
+	return ec.marshalOAnime2ᚕᚖgithubᚗcomᚋweebᚑvipᚋanimeᚑapiᚋgraphᚋmodelᚐAnimeᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Anime_relatedAnime(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Anime",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Anime_id(ctx, field)
+			case "anidbid":
+				return ec.fieldContext_Anime_anidbid(ctx, field)
+			case "thetvdbid":
+				return ec.fieldContext_Anime_thetvdbid(ctx, field)
+			case "slug":
+				return ec.fieldContext_Anime_slug(ctx, field)
+			case "titleEn":
+				return ec.fieldContext_Anime_titleEn(ctx, field)
+			case "titleJp":
+				return ec.fieldContext_Anime_titleJp(ctx, field)
+			case "titleRomaji":
+				return ec.fieldContext_Anime_titleRomaji(ctx, field)
+			case "titleKanji":
+				return ec.fieldContext_Anime_titleKanji(ctx, field)
+			case "titleSynonyms":
+				return ec.fieldContext_Anime_titleSynonyms(ctx, field)
+			case "description":
+				return ec.fieldContext_Anime_description(ctx, field)
+			case "imageUrl":
+				return ec.fieldContext_Anime_imageUrl(ctx, field)
+			case "tags":
+				return ec.fieldContext_Anime_tags(ctx, field)
+			case "studios":
+				return ec.fieldContext_Anime_studios(ctx, field)
+			case "animeStatus":
+				return ec.fieldContext_Anime_animeStatus(ctx, field)
+			case "episodeCount":
+				return ec.fieldContext_Anime_episodeCount(ctx, field)
+			case "episodes":
+				return ec.fieldContext_Anime_episodes(ctx, field)
+			case "duration":
+				return ec.fieldContext_Anime_duration(ctx, field)
+			case "rating":
+				return ec.fieldContext_Anime_rating(ctx, field)
+			case "startDate":
+				return ec.fieldContext_Anime_startDate(ctx, field)
+			case "endDate":
+				return ec.fieldContext_Anime_endDate(ctx, field)
+			case "broadcast":
+				return ec.fieldContext_Anime_broadcast(ctx, field)
+			case "source":
+				return ec.fieldContext_Anime_source(ctx, field)
+			case "licensors":
+				return ec.fieldContext_Anime_licensors(ctx, field)
+			case "ranking":
+				return ec.fieldContext_Anime_ranking(ctx, field)
+			case "malId":
+				return ec.fieldContext_Anime_malId(ctx, field)
+			case "scheduleInfo":
+				return ec.fieldContext_Anime_scheduleInfo(ctx, field)
+			case "streamingPlatforms":
+				return ec.fieldContext_Anime_streamingPlatforms(ctx, field)
+			case "fanart":
+				return ec.fieldContext_Anime_fanart(ctx, field)
+			case "seasons":
+				return ec.fieldContext_Anime_seasons(ctx, field)
+			case "type":
+				return ec.fieldContext_Anime_type(ctx, field)
+			case "relatedAnime":
+				return ec.fieldContext_Anime_relatedAnime(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Anime_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Anime_updatedAt(ctx, field)
+			case "nextEpisode":
+				return ec.fieldContext_Anime_nextEpisode(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Anime", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Anime_relatedAnime_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -6100,6 +6325,10 @@ func (ec *executionContext) fieldContext_Entity_findAnimeByID(ctx context.Contex
 				return ec.fieldContext_Anime_fanart(ctx, field)
 			case "seasons":
 				return ec.fieldContext_Anime_seasons(ctx, field)
+			case "type":
+				return ec.fieldContext_Anime_type(ctx, field)
+			case "relatedAnime":
+				return ec.fieldContext_Anime_relatedAnime(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Anime_createdAt(ctx, field)
 			case "updatedAt":
@@ -7092,6 +7321,10 @@ func (ec *executionContext) fieldContext_Query_dbSearch(ctx context.Context, fie
 				return ec.fieldContext_Anime_fanart(ctx, field)
 			case "seasons":
 				return ec.fieldContext_Anime_seasons(ctx, field)
+			case "type":
+				return ec.fieldContext_Anime_type(ctx, field)
+			case "relatedAnime":
+				return ec.fieldContext_Anime_relatedAnime(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Anime_createdAt(ctx, field)
 			case "updatedAt":
@@ -7263,6 +7496,10 @@ func (ec *executionContext) fieldContext_Query_anime(ctx context.Context, field 
 				return ec.fieldContext_Anime_fanart(ctx, field)
 			case "seasons":
 				return ec.fieldContext_Anime_seasons(ctx, field)
+			case "type":
+				return ec.fieldContext_Anime_type(ctx, field)
+			case "relatedAnime":
+				return ec.fieldContext_Anime_relatedAnime(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Anime_createdAt(ctx, field)
 			case "updatedAt":
@@ -7381,6 +7618,10 @@ func (ec *executionContext) fieldContext_Query_animeBySlug(ctx context.Context, 
 				return ec.fieldContext_Anime_fanart(ctx, field)
 			case "seasons":
 				return ec.fieldContext_Anime_seasons(ctx, field)
+			case "type":
+				return ec.fieldContext_Anime_type(ctx, field)
+			case "relatedAnime":
+				return ec.fieldContext_Anime_relatedAnime(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Anime_createdAt(ctx, field)
 			case "updatedAt":
@@ -7499,6 +7740,10 @@ func (ec *executionContext) fieldContext_Query_newestAnime(ctx context.Context, 
 				return ec.fieldContext_Anime_fanart(ctx, field)
 			case "seasons":
 				return ec.fieldContext_Anime_seasons(ctx, field)
+			case "type":
+				return ec.fieldContext_Anime_type(ctx, field)
+			case "relatedAnime":
+				return ec.fieldContext_Anime_relatedAnime(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Anime_createdAt(ctx, field)
 			case "updatedAt":
@@ -7617,6 +7862,10 @@ func (ec *executionContext) fieldContext_Query_topRatedAnime(ctx context.Context
 				return ec.fieldContext_Anime_fanart(ctx, field)
 			case "seasons":
 				return ec.fieldContext_Anime_seasons(ctx, field)
+			case "type":
+				return ec.fieldContext_Anime_type(ctx, field)
+			case "relatedAnime":
+				return ec.fieldContext_Anime_relatedAnime(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Anime_createdAt(ctx, field)
 			case "updatedAt":
@@ -7735,6 +7984,10 @@ func (ec *executionContext) fieldContext_Query_mostPopularAnime(ctx context.Cont
 				return ec.fieldContext_Anime_fanart(ctx, field)
 			case "seasons":
 				return ec.fieldContext_Anime_seasons(ctx, field)
+			case "type":
+				return ec.fieldContext_Anime_type(ctx, field)
+			case "relatedAnime":
+				return ec.fieldContext_Anime_relatedAnime(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Anime_createdAt(ctx, field)
 			case "updatedAt":
@@ -8008,6 +8261,10 @@ func (ec *executionContext) fieldContext_Query_currentlyAiring(ctx context.Conte
 				return ec.fieldContext_Anime_fanart(ctx, field)
 			case "seasons":
 				return ec.fieldContext_Anime_seasons(ctx, field)
+			case "type":
+				return ec.fieldContext_Anime_type(ctx, field)
+			case "relatedAnime":
+				return ec.fieldContext_Anime_relatedAnime(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Anime_createdAt(ctx, field)
 			case "updatedAt":
@@ -8126,6 +8383,10 @@ func (ec *executionContext) fieldContext_Query_animeBySeasons(ctx context.Contex
 				return ec.fieldContext_Anime_fanart(ctx, field)
 			case "seasons":
 				return ec.fieldContext_Anime_seasons(ctx, field)
+			case "type":
+				return ec.fieldContext_Anime_type(ctx, field)
+			case "relatedAnime":
+				return ec.fieldContext_Anime_relatedAnime(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Anime_createdAt(ctx, field)
 			case "updatedAt":
@@ -8244,6 +8505,10 @@ func (ec *executionContext) fieldContext_Query_animeBySeasonAndYear(ctx context.
 				return ec.fieldContext_Anime_fanart(ctx, field)
 			case "seasons":
 				return ec.fieldContext_Anime_seasons(ctx, field)
+			case "type":
+				return ec.fieldContext_Anime_type(ctx, field)
+			case "relatedAnime":
+				return ec.fieldContext_Anime_relatedAnime(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Anime_createdAt(ctx, field)
 			case "updatedAt":
@@ -8900,6 +9165,10 @@ func (ec *executionContext) fieldContext_StaffRole_anime(ctx context.Context, fi
 				return ec.fieldContext_Anime_fanart(ctx, field)
 			case "seasons":
 				return ec.fieldContext_Anime_seasons(ctx, field)
+			case "type":
+				return ec.fieldContext_Anime_type(ctx, field)
+			case "relatedAnime":
+				return ec.fieldContext_Anime_relatedAnime(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Anime_createdAt(ctx, field)
 			case "updatedAt":
@@ -9180,6 +9449,10 @@ func (ec *executionContext) fieldContext_UserAnime_anime(ctx context.Context, fi
 				return ec.fieldContext_Anime_fanart(ctx, field)
 			case "seasons":
 				return ec.fieldContext_Anime_seasons(ctx, field)
+			case "type":
+				return ec.fieldContext_Anime_type(ctx, field)
+			case "relatedAnime":
+				return ec.fieldContext_Anime_relatedAnime(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Anime_createdAt(ctx, field)
 			case "updatedAt":
@@ -11419,6 +11692,41 @@ func (ec *executionContext) _Anime(ctx context.Context, sel ast.SelectionSet, ob
 					}
 				}()
 				res = ec._Anime_seasons(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "type":
+			out.Values[i] = ec._Anime_type(ctx, field, obj)
+		case "relatedAnime":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Anime_relatedAnime(ctx, field, obj)
 				return res
 			}
 

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -71,10 +71,28 @@ type Anime struct {
 	// Fanart / visuals gathered for this anime
 	Fanart []*Fanart `json:"fanart,omitempty"`
 	// Anime seasons
-	Seasons     []*AnimeSeason `json:"seasons,omitempty"`
-	CreatedAt   string         `json:"createdAt"`
-	UpdatedAt   string         `json:"updatedAt"`
-	NextEpisode *Episode       `json:"nextEpisode,omitempty"`
+	Seasons []*AnimeSeason `json:"seasons,omitempty"`
+	// Record type as the source classifies it -- TV, Movie, OVA, ONA, Special and
+	// so on. Exposed because it is what separates a main entry from a side story
+	// in relatedAnime, where a list of titles alone does not say which is which.
+	Type *string `json:"type,omitempty"`
+	// Other entries in the same series, oldest first, undated last.
+	//
+	// Derived from a shared TheTVDB series id rather than from any relation the
+	// sources state: TheTVDB gives one series id to a show and everything hanging
+	// off it, so the seasons, OVAs and specials of one franchise share it. That
+	// makes this an editorial grouping rather than an inference -- but also a
+	// plain grouping, so it says these belong together and deliberately does not
+	// claim which is a sequel and which is a side story. Read `type` and
+	// `startDate` for that.
+	//
+	// Empty for the anime that have no TheTVDB id, which is most of the
+	// catalogue; callers should treat an empty list as "not known", not as
+	// "stands alone".
+	RelatedAnime []*Anime `json:"relatedAnime,omitempty"`
+	CreatedAt    string   `json:"createdAt"`
+	UpdatedAt    string   `json:"updatedAt"`
+	NextEpisode  *Episode `json:"nextEpisode,omitempty"`
 }
 
 func (Anime) IsEntity() {}

--- a/graph/types.graphqls
+++ b/graph/types.graphqls
@@ -137,6 +137,30 @@ type Anime @key(fields: "id") {
     fanart: [Fanart!] @goField(forceResolver: true)
     "Anime seasons"
     seasons: [AnimeSeason!] @goField(forceResolver: true)
+
+    """
+    Record type as the source classifies it -- TV, Movie, OVA, ONA, Special and
+    so on. Exposed because it is what separates a main entry from a side story
+    in relatedAnime, where a list of titles alone does not say which is which.
+    """
+    type: String
+
+    """
+    Other entries in the same series, oldest first, undated last.
+
+    Derived from a shared TheTVDB series id rather than from any relation the
+    sources state: TheTVDB gives one series id to a show and everything hanging
+    off it, so the seasons, OVAs and specials of one franchise share it. That
+    makes this an editorial grouping rather than an inference -- but also a
+    plain grouping, so it says these belong together and deliberately does not
+    claim which is a sequel and which is a side story. Read `type` and
+    `startDate` for that.
+
+    Empty for the anime that have no TheTVDB id, which is most of the
+    catalogue; callers should treat an empty list as "not known", not as
+    "stands alone".
+    """
+    relatedAnime(limit: Int): [Anime!] @goField(forceResolver: true)
     createdAt: String!
     updatedAt: String!
     nextEpisode: Episode @goField(forceResolver: true )

--- a/graph/types.resolvers.go
+++ b/graph/types.resolvers.go
@@ -113,6 +113,11 @@ func (r *animeResolver) Seasons(ctx context.Context, obj *model.Anime) ([]*model
 	return resolvers.AnimeSeasons(ctx, r.AnimeSeasonService, animeID)
 }
 
+// RelatedAnime is the resolver for the relatedAnime field.
+func (r *animeResolver) RelatedAnime(ctx context.Context, obj *model.Anime, limit *int) ([]*model.Anime, error) {
+	return resolvers.RelatedAnimeBySeries(ctx, r.AnimeService, obj, limit)
+}
+
 // NextEpisode is the resolver for the nextEpisode field.
 func (r *animeResolver) NextEpisode(ctx context.Context, obj *model.Anime) (*model.Episode, error) {
 	if obj.NextEpisode != nil {

--- a/internal/db/repositories/anime/anime_repository.go
+++ b/internal/db/repositories/anime/anime_repository.go
@@ -36,6 +36,7 @@ type AnimeRepositoryImpl interface {
 	FindByIdWithEpisodes(ctx context.Context, id string) (*Anime, error)
 	FindBySlug(ctx context.Context, slug string) (*Anime, error)
 	FindByIDs(ctx context.Context, ids []string) ([]*Anime, error)
+	FindBySeriesID(ctx context.Context, seriesID string, excludeID string, limit int) ([]*Anime, error)
 	FindByIDsWithEpisodes(ctx context.Context, ids []string) ([]*Anime, error)
 	FindByName(ctx context.Context, name string) ([]*Anime, error)
 	FindByNameWithEpisodes(ctx context.Context, name string) ([]*Anime, error)
@@ -1300,6 +1301,51 @@ func (a *AnimeRepository) FindByIDs(ctx context.Context, ids []string) ([]*Anime
 
 	var animes []*Anime
 	err := a.db.DB.WithContext(ctx).Where("id IN ?", ids).Find(&animes).Error
+	if err != nil {
+		_ = metrics.NewMetricsInstance().DatabaseMetric(float64(time.Since(startTime).Milliseconds()), metrics_lib.DatabaseMetricLabels{
+			Service: "anime-api",
+			Table:   "anime",
+			Method:  metrics_lib.DatabaseMetricMethodSelect,
+			Result:  metrics_lib.Error,
+			Env:     metrics.GetCurrentEnv(),
+		})
+		return nil, err
+	}
+
+	_ = metrics.NewMetricsInstance().DatabaseMetric(float64(time.Since(startTime).Milliseconds()), metrics_lib.DatabaseMetricLabels{
+		Service: "anime-api",
+		Table:   "anime",
+		Method:  metrics_lib.DatabaseMetricMethodSelect,
+		Result:  metrics_lib.Success,
+		Env:     metrics.GetCurrentEnv(),
+	})
+	return animes, nil
+}
+
+// FindBySeriesID returns the other anime sharing a TheTVDB series id, oldest
+// first with undated entries last.
+//
+// The empty-string guard is the important part. thetvdbid is nullable and a
+// good deal of the catalogue has never been enriched, but some of those rows
+// hold '' rather than NULL -- and '' = '' is true, so without this an anime
+// with a blank id would come back "related" to every other blank one. That is
+// thousands of unrelated titles, and it would look like a working feature.
+//
+// Served by idx_anime_thetvdbid from migration 000021.
+func (a *AnimeRepository) FindBySeriesID(ctx context.Context, seriesID string, excludeID string, limit int) ([]*Anime, error) {
+	startTime := time.Now()
+
+	if seriesID == "" {
+		return []*Anime{}, nil
+	}
+
+	var animes []*Anime
+	err := a.db.DB.WithContext(ctx).
+		Where("thetvdbid = ? AND id <> ?", seriesID, excludeID).
+		Order("start_date IS NULL, start_date ASC").
+		Limit(limit).
+		Find(&animes).Error
+
 	if err != nil {
 		_ = metrics.NewMetricsInstance().DatabaseMetric(float64(time.Since(startTime).Milliseconds()), metrics_lib.DatabaseMetricLabels{
 			Service: "anime-api",

--- a/internal/resolvers/anime.go
+++ b/internal/resolvers/anime.go
@@ -28,6 +28,18 @@ type CacheServiceInterface interface {
 	GetCurrentlyAiringTTL() time.Duration
 }
 
+// recordTypeToString maps the entity's RECORD_TYPE to a plain nullable string
+// for GraphQL. Kept as a helper rather than inlined because both converters
+// need it and a divergence between them is exactly the kind of thing that goes
+// unnoticed.
+func recordTypeToString(t *anime2.RECORD_TYPE) *string {
+	if t == nil {
+		return nil
+	}
+	s := string(*t)
+	return &s
+}
+
 func transformAnimeToGraphQL(animeEntity anime2.Anime) (*model.Anime, error) {
 
 	var studios []string
@@ -112,6 +124,7 @@ func transformAnimeToGraphQL(animeEntity anime2.Anime) (*model.Anime, error) {
 		Anidbid:       animeEntity.AnidbID,
 		Thetvdbid:     animeEntity.TheTVDBID,
 		Slug:          animeEntity.UrlSlug,
+		Type:          recordTypeToString(animeEntity.Type),
 		MalID:         animeEntity.MalID,
 		TitleEn:       animeEntity.TitleEn,
 		TitleJp:       animeEntity.TitleJp,
@@ -218,6 +231,7 @@ func transformAnimeToGraphQLWithEpisode(animeEntity anime2.AnimeWithNextEpisode)
 		Anidbid:       animeEntity.AnidbID,
 		Thetvdbid:     animeEntity.TheTVDBID,
 		Slug:          animeEntity.UrlSlug,
+		Type:          recordTypeToString(animeEntity.Type),
 		MalID:         animeEntity.MalID,
 		TitleEn:       animeEntity.TitleEn,
 		TitleJp:       animeEntity.TitleJp,
@@ -698,4 +712,57 @@ func DBSearchAnime(ctx context.Context, animeService anime.AnimeServiceImpl, que
 	)
 
 	return animes, nil
+}
+
+// RelatedAnimeBySeries resolves Anime.relatedAnime: the other entries sharing
+// this anime's TheTVDB series id.
+//
+// A default limit rather than none, because the groups are not uniformly small
+// -- the largest in the catalogue holds 78 anime, and a Pokemon page returning
+// all of them would be a wall of links and a much larger response than the
+// caller expected.
+func RelatedAnimeBySeries(ctx context.Context, animeService anime.AnimeServiceImpl, obj *model.Anime, limit *int) ([]*model.Anime, error) {
+	tracer := tracing.GetTracer(ctx)
+	ctx, span := tracer.Start(ctx, "RelatedAnimeBySeries",
+		trace.WithAttributes(
+			attribute.String("anime.id", obj.ID),
+			attribute.String("resolver.name", "RelatedAnimeBySeries"),
+		),
+		tracing.GetEnvironmentAttribute(),
+	)
+	defer span.End()
+
+	// No series id means nothing to group on. Not an error: most of the
+	// catalogue has never been enriched with one.
+	if obj.Thetvdbid == nil || *obj.Thetvdbid == "" {
+		span.SetAttributes(attribute.Bool("anime.has_series_id", false))
+		return []*model.Anime{}, nil
+	}
+
+	resultLimit := 25
+	if limit != nil && *limit > 0 {
+		resultLimit = *limit
+	}
+
+	found, err := animeService.RelatedAnimeBySeriesID(ctx, *obj.Thetvdbid, obj.ID, resultLimit)
+	if err != nil {
+		span.RecordError(err)
+		return nil, err
+	}
+
+	related := make([]*model.Anime, 0, len(found))
+	for _, entity := range found {
+		if entity == nil {
+			continue
+		}
+		transformed, err := transformAnimeToGraphQL(*entity)
+		if err != nil {
+			span.RecordError(err)
+			return nil, err
+		}
+		related = append(related, transformed)
+	}
+
+	span.SetAttributes(attribute.Int("anime.related_count", len(related)))
+	return related, nil
 }

--- a/internal/services/anime/anime.go
+++ b/internal/services/anime/anime.go
@@ -15,6 +15,7 @@ type AnimeServiceImpl interface {
 	AnimeBySlug(ctx context.Context, slug string) (*anime.Anime, error)
 	AnimeByIDWithEpisodes(ctx context.Context, id string) (*anime.Anime, error)
 	AnimeByIDs(ctx context.Context, ids []string) ([]*anime.Anime, error)
+	RelatedAnimeBySeriesID(ctx context.Context, seriesID string, excludeID string, limit int) ([]*anime.Anime, error)
 	AnimeByIDsWithEpisodes(ctx context.Context, ids []string) ([]*anime.Anime, error)
 	TopRatedAnime(ctx context.Context, limit int) ([]*anime.Anime, error)
 	TopRatedAnimeWithEpisodes(ctx context.Context, limit int) ([]*anime.Anime, error)
@@ -254,4 +255,11 @@ func (a *AnimeService) AnimeBySeasonWithFieldSelection(ctx context.Context, seas
 	defer span.End()
 
 	return a.Repository.FindBySeasonWithFieldSelection(ctx, season, fields, limit)
+}
+
+func (a *AnimeService) RelatedAnimeBySeriesID(ctx context.Context, seriesID string, excludeID string, limit int) ([]*anime.Anime, error) {
+	ctx, span := a.startServiceSpan(ctx, "RelatedAnimeBySeriesID")
+	defer span.End()
+
+	return a.Repository.FindBySeriesID(ctx, seriesID, excludeID, limit)
 }


### PR DESCRIPTION
Anime relations, without a new source, new scraping or any CDC pipeline work.

```graphql
type Anime {
  "TV, Movie, OVA, ONA, Special..."
  type: String
  "Other entries in the same series, oldest first, undated last"
  relatedAnime(limit: Int): [Anime!]
}
```

## Why this works with data you already have

TheTVDB gives one series id to a show and everything hanging off it, so the seasons, OVAs, movies and specials of a franchise already share one:

```
1,807 series groups contain 2+ anime, covering 6,675 titles
```

That makes this an **editorial grouping we inherit**, not an inference — no false positives to tune. The column has existed since migration `000020` and `idx_anime_thetvdbid` since `000021`, so this PR adds no migration.

## What it does and doesn't claim

It says *these belong together*. It deliberately does **not** say which is a sequel and which is a side story, because a shared series id doesn't carry that. `type` and `startDate` are exposed so callers can present the ordering without the API inventing semantics it can't support.

```
Cowboy Bebop [TV] tvdb=76885
   1998  TV Special  Cowboy Bebop: Session XX - Mish-Mash Blues
   2001  Movie       Cowboy Bebop: The Movie
   2012  Special     Cowboy Bebop: Ein's Summer Vacation
```

That's why `type` is in here — a bare list of titles doesn't tell you the movie from the main series.

## The empty-string guard

`thetvdbid` is nullable, most of the catalogue was never enriched, and **some rows hold `''` rather than `NULL`**. `'' = ''` is true, so without the guard a blank-id anime comes back related to every other blank-id anime — thousands of unrelated titles, presented as a working feature. That check is the difference between this being correct and being confidently wrong.

## Limit

Default 25. The groups aren't uniformly small — the largest holds **78** — and a Pokémon page returning all of them is a wall of links and a far larger response than the caller expected.

## Verified against the staging database

```
RIN-NE                        -> Season 2 (2016), Season 3 (2017), in order
Cowboy Bebop                  -> movie + 2 specials, types distinguishing them
Banana Fish                   -> 0 related (standalone, has an id)   correct
Yume Miru, Anime: on-chan     -> [] (no series id), not an error     correct
Pokemon (78-member group)     -> capped at 25; limit:5 returns 5     correct
```

## Coverage, honestly

9,235 of 32,039 anime have a TheTVDB id, so this covers roughly a third of the catalogue and returns an empty list elsewhere. The schema documents that an empty list means "not known", not "stands alone".

The complementary signal — anime sharing 3+ non-generic characters — reaches another ~2,200 titles this misses (Naruto, Chunibyou and Tales of Demon and God are all franchises TheTVDB doesn't group). Worth adding as a second pass later; this one is the authoritative half and stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)