### PR TITLE
perf: keep database connections warm for hours instead of minutes

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -50,10 +50,29 @@ func NewDatabase(cfg config.DBConfig) *DB {
 	sqlDB.SetMaxOpenConns(5)
 	sqlDB.SetMaxIdleConns(5)
 
-	// Long enough that connections survive quiet periods and get reused, short
-	// enough that a failover or DNS change is picked up without a restart.
-	sqlDB.SetConnMaxLifetime(30 * time.Minute)
-	sqlDB.SetConnMaxIdleTime(10 * time.Minute)
+	// Connections are kept for hours because building one is expensive here.
+	//
+	// Measured against the production RDS instance: opening a connection costs
+	// 6-52 seconds, while queries on an already-open connection cost about 7ms.
+	// The gap is TLS and SCRAM authentication, both CPU-bound, on a db.t4g.micro
+	// whose CPU credit balance sits at zero. Reconnecting is not a small cost
+	// paid occasionally, it is the single most expensive thing the service does.
+	//
+	// The old 10 minute idle timeout emptied the pool during any quiet period,
+	// so the next visitor after a lull paid that price -- which is exactly the
+	// 45 second homepage load. Holding connections through quiet periods is
+	// what removes it.
+	//
+	// It also preserves the statement cache. pgx v5 defaults to
+	// QueryExecModeCacheStatement and caches prepared statements per
+	// connection, so closing a connection discards its cached plans too. The
+	// same query then re-plans from cold: 666ms on first execution against 5ms
+	// on the second.
+	//
+	// Four hours rather than never, so a failover or DNS change is still picked
+	// up without needing a restart.
+	sqlDB.SetConnMaxLifetime(4 * time.Hour)
+	sqlDB.SetConnMaxIdleTime(1 * time.Hour)
 
 	// Initialize connection pool metrics collection
 	poolMetrics := metrics.NewConnectionPoolMetrics(db)


### PR DESCRIPTION
## Measured problem

Against the production RDS instance, from inside the cluster:

| | |
|---|---|
| open a new connection | **6,099 / 16,722 / 52,182 ms** |
| 20 queries on one open connection | **150 ms total** (~7ms each) |
| DNS resolution | 57 ms |
| raw TCP connect | 28 ms |

Neither DNS nor TCP explains it. The cost is TLS + SCRAM authentication, both CPU-bound, and `weeb-vip-db` is a `db.t4g.micro` with **CPUCreditBalance at 0** — pinned to its 10% baseline. A pure-CPU `SELECT count(*) FROM generate_series(1,5000000)` takes **21–24s** there against ~1–2s unthrottled.

So reconnecting is not a small cost paid occasionally. It is the most expensive thing the service does.

## Why this caused the 45s homepage

`ConnMaxIdleTime: 10m` emptied the pool during any quiet period. The next visitor after a lull paid the full handshake. That is the cold-start cliff, reproduced with cache-busting limits so Redis was never involved:

```
topRatedAnime(limit=41): 45.00s      limit=44: 0.64s
topRatedAnime(limit=42):  9.49s      limit=45: 0.45s
topRatedAnime(limit=43):  4.05s      limit=50: 0.49s
```

list-service shows the identical curve (8.4s → 0.22s), because the bottleneck is shared, not per-service.

## Second effect: the statement cache

pgx v5 defaults to `QueryExecModeCacheStatement` and caches prepared statements **per connection**, so closing one discards its plans:

```
1st run (cold):           666.4 ms
2nd run, identical SQL:     5.2 ms
```

Keeping connections alive keeps their plan cache alive too. This is also why adding GORM's `PrepareStmt: true` would be largely redundant — pgx already does it.

## Change

`ConnMaxLifetime` 30m → 4h, `ConnMaxIdleTime` 10m → 1h. Four hours rather than unlimited so failover and DNS changes are still picked up without a restart.

## Connection budget

`max_connections` is **79** and 37 pods in `weeb` talk to RDS, so connections cannot be made immortal everywhere — 37 × 5 would be 185. This PR covers anime-api only (2 pods × 5 = 10 retained, against 22 currently in use cluster-wide), which is safely inside the ceiling. Rolling this to the Kafka consumers needs their pools sized down first, since they process one message at a time and cannot use 5.

## What this does not fix

The instance is genuinely undersized: FreeableMemory is 61–93 MB of 1 GB and EBSByteBalance is at 0%. A 24-buffer, all-cache-hit index scan still takes ~1.4s to execute. This removes the cliff; it does not make a starved instance fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)