### PR TITLE
perf: drop eleven redundant indexes

### DIFF
--- a/db/migrations/000040_drop_redundant_idx_character_id.down.sql
+++ b/db/migrations/000040_drop_redundant_idx_character_id.down.sql
@@ -1,0 +1,2 @@
+-- Restores idx_character_id. Also alone and CONCURRENTLY, for the same reason.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_character_id ON anime_character_staff_link (character_id);

--- a/db/migrations/000040_drop_redundant_idx_character_id.up.sql
+++ b/db/migrations/000040_drop_redundant_idx_character_id.up.sql
@@ -1,0 +1,19 @@
+-- Drops idx_character_id on anime_character_staff_link (character_id).
+--
+-- Byte-for-byte identical to idx_character_staff_character_id, and both are a
+-- leading prefix of idx_character_staff (character_id, staff_id), which can
+-- serve every lookup either of them could. Three indexes on the same leading
+-- column, none of them scanned.
+--
+-- Reclaims 35 MB.
+--
+-- CONCURRENTLY, and alone in this file. golang-migrate hands the whole file to
+-- one Exec, and Postgres runs a multi-statement simple query as an implicit
+-- transaction -- where this is rejected outright with "DROP INDEX CONCURRENTLY
+-- cannot run inside a transaction block". One statement per file is what keeps
+-- it out of a transaction.
+--
+-- It matters here: a plain DROP INDEX takes ACCESS EXCLUSIVE, and
+-- anime_character_staff_link is taking tens of thousands of sequential scans,
+-- so the drop would queue behind one and block every reader after it.
+DROP INDEX CONCURRENTLY IF EXISTS idx_character_id;

--- a/db/migrations/000041_drop_redundant_idx_character_staff_character_id.down.sql
+++ b/db/migrations/000041_drop_redundant_idx_character_staff_character_id.down.sql
@@ -1,0 +1,2 @@
+-- Restores idx_character_staff_character_id. Also alone and CONCURRENTLY, for the same reason.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_character_staff_character_id ON anime_character_staff_link (character_id);

--- a/db/migrations/000041_drop_redundant_idx_character_staff_character_id.up.sql
+++ b/db/migrations/000041_drop_redundant_idx_character_staff_character_id.up.sql
@@ -1,0 +1,17 @@
+-- Drops idx_character_staff_character_id on anime_character_staff_link (character_id).
+--
+-- The other half of the duplicate pair dropped in 000040. Same columns, same
+-- redundancy against idx_character_staff, same zero scans.
+--
+-- Reclaims 35 MB.
+--
+-- CONCURRENTLY, and alone in this file. golang-migrate hands the whole file to
+-- one Exec, and Postgres runs a multi-statement simple query as an implicit
+-- transaction -- where this is rejected outright with "DROP INDEX CONCURRENTLY
+-- cannot run inside a transaction block". One statement per file is what keeps
+-- it out of a transaction.
+--
+-- It matters here: a plain DROP INDEX takes ACCESS EXCLUSIVE, and
+-- anime_character_staff_link is taking tens of thousands of sequential scans,
+-- so the drop would queue behind one and block every reader after it.
+DROP INDEX CONCURRENTLY IF EXISTS idx_character_staff_character_id;

--- a/db/migrations/000042_drop_redundant_idx_staff_id.down.sql
+++ b/db/migrations/000042_drop_redundant_idx_staff_id.down.sql
@@ -1,0 +1,2 @@
+-- Restores idx_staff_id. Also alone and CONCURRENTLY, for the same reason.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_staff_id ON anime_character_staff_link (staff_id);

--- a/db/migrations/000042_drop_redundant_idx_staff_id.up.sql
+++ b/db/migrations/000042_drop_redundant_idx_staff_id.up.sql
@@ -1,0 +1,19 @@
+-- Drops idx_staff_id on anime_character_staff_link (staff_id).
+--
+-- Duplicate of idx_character_staff_staff_id, which has the same definition and
+-- is the one actually being used (6,327 scans against this one's zero). The
+-- used index is kept: staff_id is not a prefix of idx_character_staff, so
+-- something must still index it.
+--
+-- Reclaims 10 MB.
+--
+-- CONCURRENTLY, and alone in this file. golang-migrate hands the whole file to
+-- one Exec, and Postgres runs a multi-statement simple query as an implicit
+-- transaction -- where this is rejected outright with "DROP INDEX CONCURRENTLY
+-- cannot run inside a transaction block". One statement per file is what keeps
+-- it out of a transaction.
+--
+-- It matters here: a plain DROP INDEX takes ACCESS EXCLUSIVE, and
+-- anime_character_staff_link is taking tens of thousands of sequential scans,
+-- so the drop would queue behind one and block every reader after it.
+DROP INDEX CONCURRENTLY IF EXISTS idx_staff_id;

--- a/db/migrations/000043_drop_redundant_idx_episodes_anime_id_aired.down.sql
+++ b/db/migrations/000043_drop_redundant_idx_episodes_anime_id_aired.down.sql
@@ -1,0 +1,2 @@
+-- Restores idx_episodes_anime_id_aired. Also alone and CONCURRENTLY, for the same reason.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_episodes_anime_id_aired ON episodes (anime_id, aired);

--- a/db/migrations/000043_drop_redundant_idx_episodes_anime_id_aired.up.sql
+++ b/db/migrations/000043_drop_redundant_idx_episodes_anime_id_aired.up.sql
@@ -1,0 +1,17 @@
+-- Drops idx_episodes_anime_id_aired on episodes (anime_id, aired).
+--
+-- Duplicate of idx_episodes_anime_aired -- identical columns, identical order.
+-- That one has 538 scans and this one none, so this is the copy to lose.
+--
+-- Reclaims 19 MB.
+--
+-- CONCURRENTLY, and alone in this file. golang-migrate hands the whole file to
+-- one Exec, and Postgres runs a multi-statement simple query as an implicit
+-- transaction -- where this is rejected outright with "DROP INDEX CONCURRENTLY
+-- cannot run inside a transaction block". One statement per file is what keeps
+-- it out of a transaction.
+--
+-- It matters here: a plain DROP INDEX takes ACCESS EXCLUSIVE, and
+-- anime_character_staff_link is taking tens of thousands of sequential scans,
+-- so the drop would queue behind one and block every reader after it.
+DROP INDEX CONCURRENTLY IF EXISTS idx_episodes_anime_id_aired;

--- a/db/migrations/000044_drop_redundant_idx_episodes_aired.down.sql
+++ b/db/migrations/000044_drop_redundant_idx_episodes_aired.down.sql
@@ -1,0 +1,2 @@
+-- Restores idx_episodes_aired. Also alone and CONCURRENTLY, for the same reason.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_episodes_aired ON episodes (aired);

--- a/db/migrations/000044_drop_redundant_idx_episodes_aired.up.sql
+++ b/db/migrations/000044_drop_redundant_idx_episodes_aired.up.sql
@@ -1,0 +1,17 @@
+-- Drops idx_episodes_aired on episodes (aired).
+--
+-- A leading prefix of idx_episodes_aired_anime_id (aired, anime_id), which
+-- serves the same predicates. Lightly used, and the wider index absorbs it.
+--
+-- Reclaims 3232 kB.
+--
+-- CONCURRENTLY, and alone in this file. golang-migrate hands the whole file to
+-- one Exec, and Postgres runs a multi-statement simple query as an implicit
+-- transaction -- where this is rejected outright with "DROP INDEX CONCURRENTLY
+-- cannot run inside a transaction block". One statement per file is what keeps
+-- it out of a transaction.
+--
+-- It matters here: a plain DROP INDEX takes ACCESS EXCLUSIVE, and
+-- anime_character_staff_link is taking tens of thousands of sequential scans,
+-- so the drop would queue behind one and block every reader after it.
+DROP INDEX CONCURRENTLY IF EXISTS idx_episodes_aired;

--- a/db/migrations/000045_drop_redundant_idx_anime_id.down.sql
+++ b/db/migrations/000045_drop_redundant_idx_anime_id.down.sql
@@ -1,0 +1,2 @@
+-- Restores idx_anime_id. Also alone and CONCURRENTLY, for the same reason.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_anime_id ON anime_character (anime_id);

--- a/db/migrations/000045_drop_redundant_idx_anime_id.up.sql
+++ b/db/migrations/000045_drop_redundant_idx_anime_id.up.sql
@@ -1,0 +1,18 @@
+-- Drops idx_anime_id on anime_character (anime_id).
+--
+-- Duplicate of idx_anime_character_anime_id: same table, same column, same
+-- size. That one takes 52,596 scans and this one takes none -- the planner
+-- picked one and never looked at the other.
+--
+-- Reclaims 3088 kB.
+--
+-- CONCURRENTLY, and alone in this file. golang-migrate hands the whole file to
+-- one Exec, and Postgres runs a multi-statement simple query as an implicit
+-- transaction -- where this is rejected outright with "DROP INDEX CONCURRENTLY
+-- cannot run inside a transaction block". One statement per file is what keeps
+-- it out of a transaction.
+--
+-- It matters here: a plain DROP INDEX takes ACCESS EXCLUSIVE, and
+-- anime_character_staff_link is taking tens of thousands of sequential scans,
+-- so the drop would queue behind one and block every reader after it.
+DROP INDEX CONCURRENTLY IF EXISTS idx_anime_id;

--- a/db/migrations/000046_drop_redundant_idx_anime_rating_desc.down.sql
+++ b/db/migrations/000046_drop_redundant_idx_anime_rating_desc.down.sql
@@ -1,0 +1,2 @@
+-- Restores idx_anime_rating_desc. Also alone and CONCURRENTLY, for the same reason.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_anime_rating_desc ON anime (rating DESC);

--- a/db/migrations/000046_drop_redundant_idx_anime_rating_desc.up.sql
+++ b/db/migrations/000046_drop_redundant_idx_anime_rating_desc.up.sql
@@ -1,0 +1,17 @@
+-- Drops idx_anime_rating_desc on anime (rating DESC).
+--
+-- A leading prefix of idx_anime_rating_id (rating DESC, id), which is what
+-- topRatedAnime actually plans against. Never scanned.
+--
+-- Reclaims 1416 kB.
+--
+-- CONCURRENTLY, and alone in this file. golang-migrate hands the whole file to
+-- one Exec, and Postgres runs a multi-statement simple query as an implicit
+-- transaction -- where this is rejected outright with "DROP INDEX CONCURRENTLY
+-- cannot run inside a transaction block". One statement per file is what keeps
+-- it out of a transaction.
+--
+-- It matters here: a plain DROP INDEX takes ACCESS EXCLUSIVE, and
+-- anime_character_staff_link is taking tens of thousands of sequential scans,
+-- so the drop would queue behind one and block every reader after it.
+DROP INDEX CONCURRENTLY IF EXISTS idx_anime_rating_desc;

--- a/db/migrations/000047_drop_redundant_idx_anime_ranking.down.sql
+++ b/db/migrations/000047_drop_redundant_idx_anime_ranking.down.sql
@@ -1,0 +1,2 @@
+-- Restores idx_anime_ranking. Also alone and CONCURRENTLY, for the same reason.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_anime_ranking ON anime (ranking);

--- a/db/migrations/000047_drop_redundant_idx_anime_ranking.up.sql
+++ b/db/migrations/000047_drop_redundant_idx_anime_ranking.up.sql
@@ -1,0 +1,16 @@
+-- Drops idx_anime_ranking on anime (ranking).
+--
+-- A leading prefix of idx_anime_ranking_id (ranking, id).
+--
+-- Reclaims 1192 kB.
+--
+-- CONCURRENTLY, and alone in this file. golang-migrate hands the whole file to
+-- one Exec, and Postgres runs a multi-statement simple query as an implicit
+-- transaction -- where this is rejected outright with "DROP INDEX CONCURRENTLY
+-- cannot run inside a transaction block". One statement per file is what keeps
+-- it out of a transaction.
+--
+-- It matters here: a plain DROP INDEX takes ACCESS EXCLUSIVE, and
+-- anime_character_staff_link is taking tens of thousands of sequential scans,
+-- so the drop would queue behind one and block every reader after it.
+DROP INDEX CONCURRENTLY IF EXISTS idx_anime_ranking;

--- a/db/migrations/000048_drop_redundant_idx_anime_end_date.down.sql
+++ b/db/migrations/000048_drop_redundant_idx_anime_end_date.down.sql
@@ -1,0 +1,2 @@
+-- Restores idx_anime_end_date. Also alone and CONCURRENTLY, for the same reason.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_anime_end_date ON anime (end_date);

--- a/db/migrations/000048_drop_redundant_idx_anime_end_date.up.sql
+++ b/db/migrations/000048_drop_redundant_idx_anime_end_date.up.sql
@@ -1,0 +1,16 @@
+-- Drops idx_anime_end_date on anime (end_date).
+--
+-- A leading prefix of idx_anime_end_date_id (end_date, id).
+--
+-- Reclaims 856 kB.
+--
+-- CONCURRENTLY, and alone in this file. golang-migrate hands the whole file to
+-- one Exec, and Postgres runs a multi-statement simple query as an implicit
+-- transaction -- where this is rejected outright with "DROP INDEX CONCURRENTLY
+-- cannot run inside a transaction block". One statement per file is what keeps
+-- it out of a transaction.
+--
+-- It matters here: a plain DROP INDEX takes ACCESS EXCLUSIVE, and
+-- anime_character_staff_link is taking tens of thousands of sequential scans,
+-- so the drop would queue behind one and block every reader after it.
+DROP INDEX CONCURRENTLY IF EXISTS idx_anime_end_date;

--- a/db/migrations/000049_drop_redundant_idx_anime_created_at.down.sql
+++ b/db/migrations/000049_drop_redundant_idx_anime_created_at.down.sql
@@ -1,0 +1,2 @@
+-- Restores idx_anime_created_at. Also alone and CONCURRENTLY, for the same reason.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_anime_created_at ON anime (created_at);

--- a/db/migrations/000049_drop_redundant_idx_anime_created_at.up.sql
+++ b/db/migrations/000049_drop_redundant_idx_anime_created_at.up.sql
@@ -1,0 +1,18 @@
+-- Drops idx_anime_created_at on anime (created_at).
+--
+-- Covered by idx_anime_created_at_id (created_at DESC, id). The differing sort
+-- direction does not matter: btrees scan backwards, so the wider index serves
+-- ascending order and range predicates on created_at alike.
+--
+-- Reclaims 528 kB.
+--
+-- CONCURRENTLY, and alone in this file. golang-migrate hands the whole file to
+-- one Exec, and Postgres runs a multi-statement simple query as an implicit
+-- transaction -- where this is rejected outright with "DROP INDEX CONCURRENTLY
+-- cannot run inside a transaction block". One statement per file is what keeps
+-- it out of a transaction.
+--
+-- It matters here: a plain DROP INDEX takes ACCESS EXCLUSIVE, and
+-- anime_character_staff_link is taking tens of thousands of sequential scans,
+-- so the drop would queue behind one and block every reader after it.
+DROP INDEX CONCURRENTLY IF EXISTS idx_anime_created_at;

--- a/db/migrations/000050_drop_redundant_idx_tags_name.down.sql
+++ b/db/migrations/000050_drop_redundant_idx_tags_name.down.sql
@@ -1,0 +1,2 @@
+-- Restores idx_tags_name. Also alone and CONCURRENTLY, for the same reason.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tags_name ON tags (name);

--- a/db/migrations/000050_drop_redundant_idx_tags_name.up.sql
+++ b/db/migrations/000050_drop_redundant_idx_tags_name.up.sql
@@ -1,0 +1,17 @@
+-- Drops idx_tags_name on tags (name).
+--
+-- Duplicate of tags_name_key, the index backing the UNIQUE constraint on the
+-- same column. The constraint's index cannot be dropped and does the same job.
+--
+-- Reclaims 16 kB.
+--
+-- CONCURRENTLY, and alone in this file. golang-migrate hands the whole file to
+-- one Exec, and Postgres runs a multi-statement simple query as an implicit
+-- transaction -- where this is rejected outright with "DROP INDEX CONCURRENTLY
+-- cannot run inside a transaction block". One statement per file is what keeps
+-- it out of a transaction.
+--
+-- It matters here: a plain DROP INDEX takes ACCESS EXCLUSIVE, and
+-- anime_character_staff_link is taking tens of thousands of sequential scans,
+-- so the drop would queue behind one and block every reader after it.
+DROP INDEX CONCURRENTLY IF EXISTS idx_tags_name;


### PR DESCRIPTION
Roughly **109 MB** of indexes that either duplicate another index exactly or are a leading prefix of a wider one that serves the same predicates. Scan counts are from production.

| index | table | size | scans | why it goes |
|---|---|---|---|---|
| `idx_character_id` | anime_character_staff_link | 35 MB | **0** | identical to `idx_character_staff_character_id`; both prefix `idx_character_staff` |
| `idx_character_staff_character_id` | anime_character_staff_link | 35 MB | **0** | the other half of that pair |
| `idx_staff_id` | anime_character_staff_link | 10 MB | **0** | identical to `idx_character_staff_staff_id` (6,327 scans) |
| `idx_episodes_anime_id_aired` | episodes | 19 MB | **0** | identical to `idx_episodes_anime_aired` (538 scans) |
| `idx_episodes_aired` | episodes | 3.2 MB | 279 | prefix of `idx_episodes_aired_anime_id` |
| `idx_anime_id` | anime_character | 3.0 MB | **0** | identical to `idx_anime_character_anime_id` (52,596 scans) |
| `idx_anime_rating_desc` | anime | 1.4 MB | **0** | prefix of `idx_anime_rating_id` |
| `idx_anime_ranking` | anime | 1.2 MB | 10 | prefix of `idx_anime_ranking_id` |
| `idx_anime_end_date` | anime | 856 kB | 8 | prefix of `idx_anime_end_date_id` |
| `idx_anime_created_at` | anime | 528 kB | 92 | covered by `idx_anime_created_at_id` |
| `idx_tags_name` | tags | 16 kB | **0** | duplicate of `tags_name_key`, the UNIQUE constraint's index |

`anime_character_staff_link` carried **266 MB of indexes on a 347 MB table**, 80 MB of it unreachable — three indexes on the same leading column, none scanned.

## Space is the smaller half

Every insert and update maintains **every** index on the table, and CDC writes to these continuously. 109 MB of dead index is 109 MB of write amplification and vacuum work on an instance with 2 GiB of RAM.

## Two I deliberately kept

Both are technically prefix-redundant, and dropping them would be a bad trade:

- **`idx_anime_tags_anime_id`** — 968 kB, **852,739 scans**. Covered by `anime_tags_pkey (anime_id, tag_id)` at 2.1 MB. Dropping a heavily-used narrow index to save 968 kB pushes every one of those lookups onto an index twice the size.
- **`idx_episodes_anime_id`** — 3.4 MB, 9,369 scans. Covered by `idx_episodes_anime_id_episode` at 22 MB. Same reasoning.

## Why one statement per file

`DROP INDEX CONCURRENTLY` cannot run in a transaction. golang-migrate hands each file to a single `ExecContext`, and Postgres runs a multi-statement simple query as an **implicit** transaction. Verified against production:

```
$ psql -c "SELECT 1; DROP INDEX CONCURRENTLY zz_probe;"
ERROR:  DROP INDEX CONCURRENTLY cannot run inside a transaction block
```

One statement per file keeps each drop outside a transaction — hence eleven migrations rather than one.

`CONCURRENTLY` matters rather than being defensive: a plain `DROP INDEX` takes `ACCESS EXCLUSIVE`, and `anime_character_staff_link` is taking ~37,000 sequential scans, so the drop would queue behind one and block every reader after it.

## Verification

Full chain against a clean PostgreSQL 16, via `migrate/migrate:v4.18.1`:

- all 50 migrations apply, including every `CONCURRENTLY` drop
- all 11 indexes absent afterwards; all 12 covering indexes present
- `down 11` restores all 11, `up` re-drops them, `schema_migrations: 50, dirty=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)