### PR TITLE
fix: schema-qualify immutable_unaccent so a major upgrade can run

### DIFF
--- a/db/migrations/000051_schema_qualify_immutable_unaccent.down.sql
+++ b/db/migrations/000051_schema_qualify_immutable_unaccent.down.sql
@@ -1,0 +1,7 @@
+-- Restores the unqualified body from 000038.
+--
+-- Note this reintroduces the pg_upgrade failure: a major version upgrade cannot
+-- complete while the body is unqualified.
+CREATE OR REPLACE FUNCTION immutable_unaccent(text) RETURNS text
+  LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE AS
+$$ SELECT unaccent('unaccent', $1) $$;

--- a/db/migrations/000051_schema_qualify_immutable_unaccent.up.sql
+++ b/db/migrations/000051_schema_qualify_immutable_unaccent.up.sql
@@ -1,0 +1,34 @@
+-- Schema-qualifies the body of immutable_unaccent so a major version upgrade
+-- can rebuild the generated column that depends on it.
+--
+-- The function was created in 000038 as:
+--
+--   SELECT unaccent('unaccent', $1)
+--
+-- which resolves fine in normal use, because public is on the search_path.
+-- pg_upgrade is not normal use. It restores the schema with pg_restore under a
+-- restricted search_path, and the generated column on anime_staff.url_slug
+-- calls this function, so recreating that table runs the body with nothing on
+-- the path:
+--
+--   ERROR:  function unaccent(unknown, text) does not exist
+--   LINE 1:  SELECT unaccent('unaccent', $1)
+--   CONTEXT: SQL function "immutable_unaccent" during inlining
+--
+-- That is the exact error RDS reported when 16.4 -> 18.4 was attempted:
+-- "Database instance is in a state that cannot be upgraded". The upgrade rolled
+-- back cleanly and the instance stayed on 16.4, but it cannot succeed until
+-- this is fixed.
+--
+-- Both names have to be qualified. public.unaccent is the function; the
+-- 'public.unaccent'::regdictionary cast is the text search dictionary it takes,
+-- which is looked up on the search_path in exactly the same way and fails in
+-- exactly the same place.
+--
+-- CREATE OR REPLACE rather than DROP and recreate: the generated column depends
+-- on this function by identity, so dropping it would require dropping the
+-- column. Replacing the body leaves stored values untouched -- they are not
+-- recomputed -- and the semantics are unchanged, so old and new rows agree.
+CREATE OR REPLACE FUNCTION immutable_unaccent(text) RETURNS text
+  LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE AS
+$$ SELECT public.unaccent('public.unaccent'::regdictionary, $1) $$;


### PR DESCRIPTION
The PostgreSQL 18 upgrade **failed on this**. RDS rolled back cleanly and the instance is still on 16.4, `available`, with no data loss — but the upgrade cannot succeed until this lands.

## What RDS reported

```
Database instance is in a state that cannot be upgraded:
pg_restore: from TOC entry 228; TABLE anime_staff
pg_restore: error: could not execute query:
ERROR:  function unaccent(unknown, text) does not exist
LINE 1:  SELECT unaccent('unaccent', $1)
CONTEXT: SQL function "immutable_unaccent" during inlining
```

## Why

`000038` created the function unqualified:

```sql
CREATE OR REPLACE FUNCTION immutable_unaccent(text) RETURNS text
  LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE AS
$$ SELECT unaccent('unaccent', $1) $$;
```

That resolves fine in normal use, because `public` is on the `search_path`. **`pg_upgrade` is not normal use** — it restores the schema with `pg_restore` under a restricted `search_path`, and `anime_staff.url_slug` is a generated column calling this function, so recreating that table runs the body with nothing on the path.

I checked this function during the pre-upgrade review and cleared it: it is honestly marked `IMMUTABLE`, and `pg_upgrade` does carry user functions across. Both true. I did not check that the call **inside** it was unqualified, which is the part that matters.

## The fix

```sql
$$ SELECT public.unaccent('public.unaccent'::regdictionary, $1) $$
```

**Both** names need qualifying. `public.unaccent` is the function; `'public.unaccent'::regdictionary` is the text-search dictionary it takes, which is resolved on the `search_path` the same way and fails in the same place.

`CREATE OR REPLACE`, not `DROP`/recreate — the generated column depends on the function by identity, so dropping it would mean dropping the column.

## Verified by reproducing it

On a real PostgreSQL 18, the old body under the condition `pg_restore` uses:

```
SET search_path = '';
SELECT public.immutable_unaccent_old('Ryōko');

ERROR:  function unaccent(unknown, text) does not exist
LINE 1:  SELECT unaccent('unaccent', $1)
```

Identical to the RDS failure. The new body under the same conditions returns `Ryoko`, and a generated column built on it creates and populates correctly (`ryoko-ono`).

Also confirmed `CREATE OR REPLACE` is safe with a dependent generated column: **stored values are not recomputed**, new rows use the new body, and both produce identical output — so this is a no-op for data.

Full chain applies on a clean PG 18 (51 migrations), and `down 1` / `up` round-trips.

## After this

Re-running the terraform apply should get past the pre-check. Note the earlier run also left a second error worth knowing about — Terraform tried to delete the old `postgres16` parameter group while the instance was still attached (`InvalidDBParameterGroupState`). That was a consequence of the upgrade failing, not a separate problem: with the version change succeeding, the instance moves to the `postgres18` group and the old one becomes deletable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)