### PR TITLE
perf: drop ten indexes on anime that no query can use

### DIFF
--- a/db/migrations/000052_drop_unused_idx_anime_title_en.down.sql
+++ b/db/migrations/000052_drop_unused_idx_anime_title_en.down.sql
@@ -1,0 +1,2 @@
+-- Restores idx_anime_title_en. Also alone and CONCURRENTLY, for the same reason.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_anime_title_en ON anime (title_en);

--- a/db/migrations/000052_drop_unused_idx_anime_title_en.up.sql
+++ b/db/migrations/000052_drop_unused_idx_anime_title_en.up.sql
@@ -1,0 +1,18 @@
+-- Drops idx_anime_title_en on anime (title_en).
+--
+-- Search is the only thing that touches this column, and it uses a leading
+-- wildcard:
+--
+--   WHERE title_en LIKE '%term%' OR title_jp LIKE '%term%' OR ...
+--
+-- A btree cannot answer that. The index is not merely unused, it is incapable
+-- of being used by the only query that reads the column, which is why it had
+-- zero scans over the whole window before the upgrade reset the counters.
+--
+-- Reclaims 2416 kB.
+--
+-- CONCURRENTLY, and alone in this file. golang-migrate hands the whole file to
+-- one Exec, and Postgres runs a multi-statement simple query as an implicit
+-- transaction -- where this is rejected with "DROP INDEX CONCURRENTLY cannot
+-- run inside a transaction block". One statement per file keeps it out of one.
+DROP INDEX CONCURRENTLY IF EXISTS idx_anime_title_en;

--- a/db/migrations/000053_drop_unused_idx_anime_title_jp.down.sql
+++ b/db/migrations/000053_drop_unused_idx_anime_title_jp.down.sql
@@ -1,0 +1,2 @@
+-- Restores idx_anime_title_jp. Also alone and CONCURRENTLY, for the same reason.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_anime_title_jp ON anime (title_jp);

--- a/db/migrations/000053_drop_unused_idx_anime_title_jp.up.sql
+++ b/db/migrations/000053_drop_unused_idx_anime_title_jp.up.sql
@@ -1,0 +1,11 @@
+-- Drops idx_anime_title_jp on anime (title_jp).
+--
+-- Same leading-wildcard search as 000052. A btree cannot serve LIKE '%term%'.
+--
+-- Reclaims 2600 kB.
+--
+-- CONCURRENTLY, and alone in this file. golang-migrate hands the whole file to
+-- one Exec, and Postgres runs a multi-statement simple query as an implicit
+-- transaction -- where this is rejected with "DROP INDEX CONCURRENTLY cannot
+-- run inside a transaction block". One statement per file keeps it out of one.
+DROP INDEX CONCURRENTLY IF EXISTS idx_anime_title_jp;

--- a/db/migrations/000054_drop_unused_idx_anime_title_kanji.down.sql
+++ b/db/migrations/000054_drop_unused_idx_anime_title_kanji.down.sql
@@ -1,0 +1,2 @@
+-- Restores idx_anime_title_kanji. Also alone and CONCURRENTLY, for the same reason.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_anime_title_kanji ON anime (title_kanji);

--- a/db/migrations/000054_drop_unused_idx_anime_title_kanji.up.sql
+++ b/db/migrations/000054_drop_unused_idx_anime_title_kanji.up.sql
@@ -1,0 +1,11 @@
+-- Drops idx_anime_title_kanji on anime (title_kanji).
+--
+-- Same leading-wildcard search as 000052.
+--
+-- Reclaims 536 kB.
+--
+-- CONCURRENTLY, and alone in this file. golang-migrate hands the whole file to
+-- one Exec, and Postgres runs a multi-statement simple query as an implicit
+-- transaction -- where this is rejected with "DROP INDEX CONCURRENTLY cannot
+-- run inside a transaction block". One statement per file keeps it out of one.
+DROP INDEX CONCURRENTLY IF EXISTS idx_anime_title_kanji;

--- a/db/migrations/000055_drop_unused_idx_anime_title_romaji.down.sql
+++ b/db/migrations/000055_drop_unused_idx_anime_title_romaji.down.sql
@@ -1,0 +1,2 @@
+-- Restores idx_anime_title_romaji. Also alone and CONCURRENTLY, for the same reason.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_anime_title_romaji ON anime (title_romaji);

--- a/db/migrations/000055_drop_unused_idx_anime_title_romaji.up.sql
+++ b/db/migrations/000055_drop_unused_idx_anime_title_romaji.up.sql
@@ -1,0 +1,11 @@
+-- Drops idx_anime_title_romaji on anime (title_romaji).
+--
+-- Same leading-wildcard search as 000052.
+--
+-- Reclaims 536 kB.
+--
+-- CONCURRENTLY, and alone in this file. golang-migrate hands the whole file to
+-- one Exec, and Postgres runs a multi-statement simple query as an implicit
+-- transaction -- where this is rejected with "DROP INDEX CONCURRENTLY cannot
+-- run inside a transaction block". One statement per file keeps it out of one.
+DROP INDEX CONCURRENTLY IF EXISTS idx_anime_title_romaji;

--- a/db/migrations/000056_drop_unused_idx_anime_mal_id.down.sql
+++ b/db/migrations/000056_drop_unused_idx_anime_mal_id.down.sql
@@ -1,0 +1,2 @@
+-- Restores idx_anime_mal_id. Also alone and CONCURRENTLY, for the same reason.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_anime_mal_id ON anime (mal_id);

--- a/db/migrations/000056_drop_unused_idx_anime_mal_id.up.sql
+++ b/db/migrations/000056_drop_unused_idx_anime_mal_id.up.sql
@@ -1,0 +1,14 @@
+-- Drops idx_anime_mal_id on anime (mal_id).
+--
+-- mal_id is only ever selected, never filtered on: it appears in the field
+-- selection map and in SELECT lists, and in no WHERE clause anywhere in the
+-- repository. An index on a column nothing searches by is maintained on every
+-- write and read by nothing.
+--
+-- Reclaims 1440 kB.
+--
+-- CONCURRENTLY, and alone in this file. golang-migrate hands the whole file to
+-- one Exec, and Postgres runs a multi-statement simple query as an implicit
+-- transaction -- where this is rejected with "DROP INDEX CONCURRENTLY cannot
+-- run inside a transaction block". One statement per file keeps it out of one.
+DROP INDEX CONCURRENTLY IF EXISTS idx_anime_mal_id;

--- a/db/migrations/000057_drop_unused_idx_anime_anidbid.down.sql
+++ b/db/migrations/000057_drop_unused_idx_anime_anidbid.down.sql
@@ -1,0 +1,2 @@
+-- Restores idx_anime_anidbid. Also alone and CONCURRENTLY, for the same reason.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_anime_anidbid ON anime (anidbid);

--- a/db/migrations/000057_drop_unused_idx_anime_anidbid.up.sql
+++ b/db/migrations/000057_drop_unused_idx_anime_anidbid.up.sql
@@ -1,0 +1,11 @@
+-- Drops idx_anime_anidbid on anime (anidbid).
+--
+-- Same as 000056: anidbid is selected, never filtered on.
+--
+-- Reclaims 1008 kB.
+--
+-- CONCURRENTLY, and alone in this file. golang-migrate hands the whole file to
+-- one Exec, and Postgres runs a multi-statement simple query as an implicit
+-- transaction -- where this is rejected with "DROP INDEX CONCURRENTLY cannot
+-- run inside a transaction block". One statement per file keeps it out of one.
+DROP INDEX CONCURRENTLY IF EXISTS idx_anime_anidbid;

--- a/db/migrations/000058_drop_unused_idx_anime_type.down.sql
+++ b/db/migrations/000058_drop_unused_idx_anime_type.down.sql
@@ -1,0 +1,2 @@
+-- Restores idx_anime_type. Also alone and CONCURRENTLY, for the same reason.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_anime_type ON anime (type);

--- a/db/migrations/000058_drop_unused_idx_anime_type.up.sql
+++ b/db/migrations/000058_drop_unused_idx_anime_type.up.sql
@@ -1,0 +1,16 @@
+-- Drops idx_anime_type on anime (type).
+--
+-- The only query filtering on type is FindByType (and FindByTypeWithEpisodes),
+-- which has no caller outside the repository and is not exposed in the GraphQL
+-- schema. The index supports a method nothing can reach.
+--
+-- Worth restoring alongside the method if it is ever wired up -- unlike the
+-- title indexes above, this one would work.
+--
+-- Reclaims 608 kB.
+--
+-- CONCURRENTLY, and alone in this file. golang-migrate hands the whole file to
+-- one Exec, and Postgres runs a multi-statement simple query as an implicit
+-- transaction -- where this is rejected with "DROP INDEX CONCURRENTLY cannot
+-- run inside a transaction block". One statement per file keeps it out of one.
+DROP INDEX CONCURRENTLY IF EXISTS idx_anime_type;

--- a/db/migrations/000059_drop_unused_idx_anime_status.down.sql
+++ b/db/migrations/000059_drop_unused_idx_anime_status.down.sql
@@ -1,0 +1,2 @@
+-- Restores idx_anime_status. Also alone and CONCURRENTLY, for the same reason.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_anime_status ON anime (status);

--- a/db/migrations/000059_drop_unused_idx_anime_status.up.sql
+++ b/db/migrations/000059_drop_unused_idx_anime_status.up.sql
@@ -1,0 +1,12 @@
+-- Drops idx_anime_status on anime (status).
+--
+-- Same as 000058: FindByStatus has no caller outside the repository and is not
+-- in the schema.
+--
+-- Reclaims 696 kB.
+--
+-- CONCURRENTLY, and alone in this file. golang-migrate hands the whole file to
+-- one Exec, and Postgres runs a multi-statement simple query as an implicit
+-- transaction -- where this is rejected with "DROP INDEX CONCURRENTLY cannot
+-- run inside a transaction block". One statement per file keeps it out of one.
+DROP INDEX CONCURRENTLY IF EXISTS idx_anime_status;

--- a/db/migrations/000060_drop_unused_idx_anime_source.down.sql
+++ b/db/migrations/000060_drop_unused_idx_anime_source.down.sql
@@ -1,0 +1,2 @@
+-- Restores idx_anime_source. Also alone and CONCURRENTLY, for the same reason.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_anime_source ON anime (source);

--- a/db/migrations/000060_drop_unused_idx_anime_source.up.sql
+++ b/db/migrations/000060_drop_unused_idx_anime_source.up.sql
@@ -1,0 +1,12 @@
+-- Drops idx_anime_source on anime (source).
+--
+-- Same as 000058: FindBySource has no caller outside the repository and is not
+-- in the schema.
+--
+-- Reclaims 616 kB.
+--
+-- CONCURRENTLY, and alone in this file. golang-migrate hands the whole file to
+-- one Exec, and Postgres runs a multi-statement simple query as an implicit
+-- transaction -- where this is rejected with "DROP INDEX CONCURRENTLY cannot
+-- run inside a transaction block". One statement per file keeps it out of one.
+DROP INDEX CONCURRENTLY IF EXISTS idx_anime_source;

--- a/db/migrations/000061_drop_unused_idx_anime_start_date.down.sql
+++ b/db/migrations/000061_drop_unused_idx_anime_start_date.down.sql
@@ -1,0 +1,2 @@
+-- Restores idx_anime_start_date. Also alone and CONCURRENTLY, for the same reason.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_anime_start_date ON anime (start_date);

--- a/db/migrations/000061_drop_unused_idx_anime_start_date.up.sql
+++ b/db/migrations/000061_drop_unused_idx_anime_start_date.up.sql
@@ -1,0 +1,15 @@
+-- Drops idx_anime_start_date on anime (start_date).
+--
+-- start_date appears in no WHERE clause and no ORDER BY in the repository. It is
+-- selected and returned, nothing more.
+--
+-- Note this is not the airing-window query: that filters on end_date and is
+-- served by idx_anime_end_date_id, which stays.
+--
+-- Reclaims 1152 kB.
+--
+-- CONCURRENTLY, and alone in this file. golang-migrate hands the whole file to
+-- one Exec, and Postgres runs a multi-statement simple query as an implicit
+-- transaction -- where this is rejected with "DROP INDEX CONCURRENTLY cannot
+-- run inside a transaction block". One statement per file keeps it out of one.
+DROP INDEX CONCURRENTLY IF EXISTS idx_anime_start_date;


### PR DESCRIPTION
~11.5 MB across ten indexes on `anime`, leaving seven.

## Why not scan counts this time

**`pg_upgrade` reset the statistics.** After the move to Postgres 18 the instance had 8 minutes of uptime and `stats_reset` was null, so nearly every index reads as 0 scans — including ones I know are used. Judging "unused" from that would drop working indexes.

So every drop here is justified by **what the queries do**, not by how often something was counted.

## The four that cannot work

Search is the only thing that reads the title columns, and it uses a **leading wildcard**:

```go
Where("title_en LIKE ? OR title_jp LIKE ? OR title_synonyms LIKE ? OR
       title_romaji LIKE ? OR title_kanji LIKE ?", "%"+search+"%", ...)
```

A btree cannot answer `LIKE '%term%'`. `idx_anime_title_en`, `title_jp`, `title_kanji` and `title_romaji` are not merely unused — they are **incapable** of serving the only query that reads those columns.

*(If title search ever needs to be fast, the answer is a trigram index — `pg_trgm` with a GIN index — not these.)*

## Two on columns nothing filters by

`mal_id` and `anidbid` appear in SELECT lists and the field-selection map, and in **no `WHERE` clause anywhere in the repository**. Maintained on every write, read by nothing.

## Three supporting unreachable code

`idx_anime_type`, `idx_anime_status`, `idx_anime_source` back `FindByType`, `FindByStatus` and `FindBySource` — which have **no caller outside the repository** and are **not in the GraphQL schema**.

These differ from the title indexes: they *would* work if the methods were wired up. The migrations say so, so restoring them alongside the method is the obvious move rather than a rediscovery.

## One column never filtered or ordered

`start_date` appears in no `WHERE` and no `ORDER BY`. Note this is **not** the airing-window query — that filters on `end_date`, and `idx_anime_end_date_id` stays.

## What remains, and why

| index | serves |
|---|---|
| `anime_pkey` | primary key |
| `idx_anime_created_at_id` | `newestAnime` — `ORDER BY created_at DESC, id` |
| `idx_anime_rating_id` | `topRatedAnime` — `WHERE rating IS NOT NULL ORDER BY rating DESC, id` |
| `idx_anime_ranking_id` | `WHERE ranking IS NOT NULL ORDER BY ranking ASC, id` |
| `idx_anime_end_date_id` | the airing window |
| `idx_anime_url_slug` | actively scanned |
| `idx_anime_thetvdbid` | actively scanned |

## Verification

Full chain on a clean **PostgreSQL 18**: all 61 migrations apply, exactly those seven indexes remain, `down 10` restores all 17, `up` drops them again, `schema_migrations: 61, dirty=f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)