### PR TITLE
perf: align id column types so character joins can use an index

### DIFF
--- a/db/migrations/000062_align_id_column_types.down.sql
+++ b/db/migrations/000062_align_id_column_types.down.sql
@@ -1,0 +1,9 @@
+-- Restores char(36).
+--
+-- Note this reintroduces the problem: joins from anime_character_staff_link
+-- back to these tables will cast the indexed column again and fall back to a
+-- sequential scan of every link row.
+ALTER TABLE anime_relations ALTER COLUMN id TYPE char(36);
+ALTER TABLE anime_character_staff_link ALTER COLUMN id TYPE char(36);
+ALTER TABLE anime_staff ALTER COLUMN id TYPE char(36);
+ALTER TABLE anime_character ALTER COLUMN id TYPE char(36);

--- a/db/migrations/000062_align_id_column_types.up.sql
+++ b/db/migrations/000062_align_id_column_types.up.sql
@@ -1,0 +1,40 @@
+-- Converts the four remaining char(36) id columns to varchar(36), so joins
+-- against them can use an index.
+--
+-- anime_character.id and anime_staff.id are char(36); the columns that
+-- reference them, anime_character_staff_link.character_id and .staff_id, are
+-- varchar(36). Postgres resolves that mismatch by casting, and the cast lands
+-- on the indexed side:
+--
+--   Hash Cond: ((anime_character_staff_link.character_id)::bpchar = anime_character.id)
+--   ->  Parallel Seq Scan on anime_character_staff_link (rows=149862 loops=3)
+--
+-- A cast on the indexed column makes the index unusable, so every request for
+-- an anime's characters read all 450,000 link rows instead of the handful it
+-- needed. That is why idx_character_staff, at 116MB, had 149 scans while the
+-- table had 37,000 sequential scans, and why this query was the largest CPU
+-- consumer in Performance Insights.
+--
+-- Measured on a reproduction of the same shape and volume:
+--
+--   before:  Parallel Seq Scan, 150000 rows x 3 workers   18.9ms
+--   after:   Index Only Scan,   2 rows x 75 loops          2.1ms
+--
+-- varchar is the direction rather than char because varchar is what the rest of
+-- the schema uses: these four were the only char columns against thirty-six
+-- varchar ones. char(36) also blank-pads and compares with trailing-space
+-- semantics, which is a trap for the next join written against them.
+--
+-- This does not rewrite the tables. bpchar and varchar share a representation,
+-- so Postgres treats the change as binary-coercible: it updates the catalog and
+-- revalidates. The two foreign keys survive untouched -- verified, not assumed.
+--
+-- The values are 36-character UUIDs, so there is no padding to lose.
+--
+-- One transaction, so a failure leaves every column on its original type rather
+-- than half-converted. Each ALTER takes an ACCESS EXCLUSIVE lock for the
+-- duration; on the row counts here that measured under a second per table.
+ALTER TABLE anime_character ALTER COLUMN id TYPE varchar(36);
+ALTER TABLE anime_staff ALTER COLUMN id TYPE varchar(36);
+ALTER TABLE anime_character_staff_link ALTER COLUMN id TYPE varchar(36);
+ALTER TABLE anime_relations ALTER COLUMN id TYPE varchar(36);


### PR DESCRIPTION
The top CPU consumer in Performance Insights was the character/staff query. The cause is a **type mismatch**, not a missing index.

## What the planner does today

```
Hash Cond: ((anime_character_staff_link.character_id)::bpchar = anime_character.id)
  ->  Parallel Seq Scan on anime_character_staff_link (rows=149862 loops=3)
```

| column | type |
|---|---|
| `anime_character.id` | `character(36)` |
| `anime_staff.id` | `character(36)` |
| `anime_character_staff_link.character_id` | `character varying(36)` |
| `anime_character_staff_link.staff_id` | `character varying(36)` |

Postgres reconciles the mismatch with a cast, and **the cast lands on the indexed column** — which makes the index unusable. So fetching one anime's characters reads all **450,000** link rows.

That explains the anomaly flagged earlier: `idx_character_staff` is **116 MB** and had **149 scans**, while the table took **37,000 sequential scans**. The index was never the problem; nothing could use it.

## Measured

Against production, moving the cast to the other side (so the index stays untouched):

```
current shape           94.7 ms    parallel seq scan
cast moved              32.9 ms    index only scan     -- identical 3,338 rows
```

And on a reproduction of the same shape and volume, applying this migration:

```
before:  Parallel Seq Scan   150,000 rows x 3 workers   18.9 ms
after:   Index Only Scan     2 rows x 75 loops           2.1 ms
```

## Why varchar, not char

`varchar` is what the rest of the schema uses — these four were the **only** `char` columns against **thirty-six** `varchar` ones. `char(n)` also blank-pads and compares with trailing-space semantics, which is exactly the trap the next join would fall into.

## This does not rewrite the tables

`bpchar` and `varchar` share a representation, so Postgres treats the change as binary-coercible: catalog update and revalidate, no rewrite. Measured at **~900 ms** for a 225,000-row table. The values are 36-character UUIDs, so there is no padding to lose.

**Both foreign keys survive** — verified on a reproduction, not assumed:

```
fk_character_id | FOREIGN KEY (character_id) REFERENCES anime_character(id) ON DELETE CASCADE
fk_staff_id     | FOREIGN KEY (staff_id) REFERENCES anime_staff(id) ON DELETE CASCADE
```

One transaction, so a failure leaves every column on its original type rather than half-converted. Each `ALTER` takes an `ACCESS EXCLUSIVE` lock for its duration.

## Verified

Full chain on a clean PostgreSQL 18: applies, **zero** `character` columns remain, both FKs intact, `down 1` restores all four, `up` re-applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)