### PR TITLE
feat: relate anime that adapt the same source work

### DIFF
--- a/.github/workflows/migrations.yaml
+++ b/.github/workflows/migrations.yaml
@@ -74,17 +74,17 @@ jobs:
             SELECT count(*) INTO n FROM information_schema.tables
               WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
                 AND table_name <> 'schema_migrations';
-            IF n <> 14 THEN
-              RAISE EXCEPTION 'expected 14 tables, found %', n;
+            IF n <> 15 THEN
+              RAISE EXCEPTION 'expected 15 tables, found %', n;
             END IF;
 
             SELECT count(*) INTO n FROM information_schema.columns
               WHERE table_schema = 'public' AND table_name <> 'schema_migrations';
-            IF n <> 156 THEN
-              RAISE EXCEPTION 'expected 156 columns, found %', n;
+            IF n <> 179 THEN
+              RAISE EXCEPTION 'expected 179 columns, found %', n;
             END IF;
 
-            -- Three episode-count triggers plus eight updated_at triggers.
+            -- Three episode-count triggers plus ten updated_at triggers.
             SELECT count(*) INTO n FROM information_schema.triggers
               WHERE trigger_schema = 'public';
             IF n < 11 THEN

--- a/db/migrations/000063_add_work_and_anime_source_work.down.sql
+++ b/db/migrations/000063_add_work_and_anime_source_work.down.sql
@@ -1,3 +1,4 @@
+DROP TRIGGER IF EXISTS work_set_updated_at ON "work";
 DROP INDEX IF EXISTS "idx_anime_source_work_id";
 ALTER TABLE "anime" DROP COLUMN IF EXISTS "source_work_id";
 DROP INDEX IF EXISTS "idx_work_mal_id";

--- a/db/migrations/000063_add_work_and_anime_source_work.down.sql
+++ b/db/migrations/000063_add_work_and_anime_source_work.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS "idx_anime_source_work_id";
+ALTER TABLE "anime" DROP COLUMN IF EXISTS "source_work_id";
+DROP INDEX IF EXISTS "idx_work_mal_id";
+DROP TABLE IF EXISTS "work";

--- a/db/migrations/000063_add_work_and_anime_source_work.up.sql
+++ b/db/migrations/000063_add_work_and_anime_source_work.up.sql
@@ -54,6 +54,13 @@ ALTER TABLE "anime" ADD COLUMN IF NOT EXISTS "source_work_id" varchar(36);
 -- adapted from the same work, which is the relation itself.
 CREATE INDEX IF NOT EXISTS "idx_anime_source_work_id" ON "anime" ("source_work_id");
 
+-- Every table here carries this trigger, so work does too. The sync service
+-- writes updated_at from the CDC event, but a manual correction applied
+-- directly to the read store would otherwise leave the column stale, and
+-- nothing downstream could tell the row had changed.
+CREATE TRIGGER work_set_updated_at BEFORE UPDATE ON "work"
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
 -- No foreign key, matching the scraper. CDC makes no ordering promise across
 -- tables, so an anime routinely arrives before the work it points at; anime-sync
 -- already discards foreign key violations for exactly this reason, and a

--- a/db/migrations/000063_add_work_and_anime_source_work.up.sql
+++ b/db/migrations/000063_add_work_and_anime_source_work.up.sql
@@ -1,0 +1,60 @@
+-- Adds `work` and `anime.source_work_id`: the manga, light novels and novels
+-- anime are adapted from, and the pointer to them.
+--
+-- This is the read-store half of the scraper's `work` table. The scraper owns
+-- the data; Debezium already captures the table with no configuration change,
+-- because it runs with schema.include.list=public and no table filter, and
+-- ANIMEDB already claims anime-db.> so the subject and its retention exist
+-- too. What did not exist is somewhere for it to land, which is this.
+--
+-- Why it matters: `anime.source` records a category, never an identity. We
+-- know 6,110 anime came from a manga and cannot say which one, so
+-- re-adaptations of the same source look unrelated -- Fruits Basket 2001 and
+-- 2019, Hunter x Hunter 1999 and 2011, Fullmetal Alchemist and Brotherhood.
+-- They share no TheTVDB series id and frequently no cast, so both signals
+-- behind relatedAnime miss them. The source work is the only thing connecting
+-- them.
+
+CREATE TABLE IF NOT EXISTS "work" (
+    "id"              varchar(36) NOT NULL,
+    "mal_id"          integer,
+    "type"            varchar(32) NOT NULL DEFAULT 'MANGA',
+    "title_en"        varchar(255),
+    "title_jp"        varchar(255),
+    "title_synonyms"  text,
+    "synopsis"        text,
+    "image_url"       varchar(512),
+    "status"          varchar(64),
+    "volumes"         integer,
+    "chapters"        integer,
+    "published_from"  timestamptz,
+    "published_to"    timestamptz,
+    "demographic"     varchar(64),
+    "serialization"   varchar(255),
+    "authors"         text,
+    "score"           numeric(4,2),
+    "ranking"         integer,
+    "members"         integer,
+    "favorites"       integer,
+    "created_at"      timestamptz NOT NULL DEFAULT now(),
+    "updated_at"      timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT "work_pkey" PRIMARY KEY ("id")
+);
+
+-- varchar(36), not char(36) or uuid. The rest of this schema is varchar(36)
+-- and migration 000062 exists precisely because four char(36) columns forced a
+-- cast that made their indexes unusable. A uuid column here would repeat that
+-- against anime.source_work_id.
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_work_mal_id" ON "work" ("mal_id");
+
+ALTER TABLE "anime" ADD COLUMN IF NOT EXISTS "source_work_id" varchar(36);
+
+-- The index that earns its keep is this one, not the forward lookup. An anime's
+-- own source is already on its row; what needs finding is every other anime
+-- adapted from the same work, which is the relation itself.
+CREATE INDEX IF NOT EXISTS "idx_anime_source_work_id" ON "anime" ("source_work_id");
+
+-- No foreign key, matching the scraper. CDC makes no ordering promise across
+-- tables, so an anime routinely arrives before the work it points at; anime-sync
+-- already discards foreign key violations for exactly this reason, and a
+-- constraint here would turn ordinary event ordering into dropped rows.

--- a/graph/generated/generated.go
+++ b/graph/generated/generated.go
@@ -76,6 +76,7 @@ type ComplexityRoot struct {
 		Seasons            func(childComplexity int) int
 		Slug               func(childComplexity int) int
 		Source             func(childComplexity int) int
+		SourceWorkID       func(childComplexity int) int
 		StartDate          func(childComplexity int) int
 		StreamingPlatforms func(childComplexity int) int
 		Studios            func(childComplexity int) int
@@ -463,6 +464,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Anime.Source(childComplexity), true
+
+	case "Anime.sourceWorkId":
+		if e.complexity.Anime.SourceWorkID == nil {
+			break
+		}
+
+		return e.complexity.Anime.SourceWorkID(childComplexity), true
 
 	case "Anime.startDate":
 		if e.complexity.Anime.StartDate == nil {
@@ -1579,6 +1587,15 @@ type Anime @key(fields: "id") {
     anidbid: String
     "TheTVDB ID of the anime"
     thetvdbid: String
+
+    """
+    The work this anime adapts, when we know it -- the manga or novel, not the
+    category ` + "`" + `source` + "`" + ` gives. Null for originals and for sources MyAnimeList's
+    manga database does not cover, which together are most of the catalogue.
+
+    Exposed because relatedAnime resolves SHARED_SOURCE from it.
+    """
+    sourceWorkId: String
     """
     Public URL segment for the anime, e.g. "cowboy-bebop". Derived from the
     title, with a year and type appended only where several anime would
@@ -1675,16 +1692,8 @@ type RelatedAnime {
 """
 The ways two anime can be connected.
 
-Only kinds we can actually establish appear here. Two more are wanted and are
-absent because the data does not support them yet:
-
-A shared source work. Most anime adapt something, and the manga or novel is
-what ties the adaptations together -- Fruits Basket in 2001 and 2019, Hunter x
-Hunter in 1999 and 2011, Fullmetal Alchemist and Brotherhood. Those share no
-TheTVDB series id and frequently no cast, so nothing else finds them. We record
-` + "`" + `source` + "`" + ` as a category ("Manga", "Light novel") and not as an identity, so we
-know an anime came from a manga but never which one; this needs the work itself
-modelled and anime pointed at it.
+Only kinds we can actually establish appear here. One more is wanted and is
+absent because the data does not support it yet:
 
 A shared creator, the thread joining Serial Experiments Lain and Haibane
 Renmei. That needs staff credited against an anime by role, and anime_staff
@@ -1696,6 +1705,19 @@ enum AnimeRelation {
     its TheTVDB series id. The same show, not a different one.
     """
     SAME_SERIES
+
+    """
+    A separate adaptation of the same source work -- Fruits Basket in 2001 and
+    2019, Hunter x Hunter in 1999 and 2011, Fullmetal Alchemist and
+    Brotherhood.
+
+    A different show, not another entry in one: these are distinct productions,
+    often years and a studio apart, telling the same story again. They share no
+    TheTVDB series id and frequently no cast, which is why SAME_SERIES cannot
+    reach them and why the source work had to be modelled as an identity rather
+    than the category ` + "`" + `source` + "`" + ` records.
+    """
+    SHARED_SOURCE
 }
 
 type AnimeSeason {
@@ -2486,6 +2508,47 @@ func (ec *executionContext) _Anime_thetvdbid(ctx context.Context, field graphql.
 }
 
 func (ec *executionContext) fieldContext_Anime_thetvdbid(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Anime",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Anime_sourceWorkId(ctx context.Context, field graphql.CollectedField, obj *model.Anime) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Anime_sourceWorkId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SourceWorkID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Anime_sourceWorkId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Anime",
 		Field:      field,
@@ -6261,6 +6324,8 @@ func (ec *executionContext) fieldContext_Entity_findAnimeByID(ctx context.Contex
 				return ec.fieldContext_Anime_anidbid(ctx, field)
 			case "thetvdbid":
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
+			case "sourceWorkId":
+				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -7257,6 +7322,8 @@ func (ec *executionContext) fieldContext_Query_dbSearch(ctx context.Context, fie
 				return ec.fieldContext_Anime_anidbid(ctx, field)
 			case "thetvdbid":
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
+			case "sourceWorkId":
+				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -7432,6 +7499,8 @@ func (ec *executionContext) fieldContext_Query_anime(ctx context.Context, field 
 				return ec.fieldContext_Anime_anidbid(ctx, field)
 			case "thetvdbid":
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
+			case "sourceWorkId":
+				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -7554,6 +7623,8 @@ func (ec *executionContext) fieldContext_Query_animeBySlug(ctx context.Context, 
 				return ec.fieldContext_Anime_anidbid(ctx, field)
 			case "thetvdbid":
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
+			case "sourceWorkId":
+				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -7676,6 +7747,8 @@ func (ec *executionContext) fieldContext_Query_newestAnime(ctx context.Context, 
 				return ec.fieldContext_Anime_anidbid(ctx, field)
 			case "thetvdbid":
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
+			case "sourceWorkId":
+				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -7798,6 +7871,8 @@ func (ec *executionContext) fieldContext_Query_topRatedAnime(ctx context.Context
 				return ec.fieldContext_Anime_anidbid(ctx, field)
 			case "thetvdbid":
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
+			case "sourceWorkId":
+				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -7920,6 +7995,8 @@ func (ec *executionContext) fieldContext_Query_mostPopularAnime(ctx context.Cont
 				return ec.fieldContext_Anime_anidbid(ctx, field)
 			case "thetvdbid":
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
+			case "sourceWorkId":
+				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -8197,6 +8274,8 @@ func (ec *executionContext) fieldContext_Query_currentlyAiring(ctx context.Conte
 				return ec.fieldContext_Anime_anidbid(ctx, field)
 			case "thetvdbid":
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
+			case "sourceWorkId":
+				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -8319,6 +8398,8 @@ func (ec *executionContext) fieldContext_Query_animeBySeasons(ctx context.Contex
 				return ec.fieldContext_Anime_anidbid(ctx, field)
 			case "thetvdbid":
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
+			case "sourceWorkId":
+				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -8441,6 +8522,8 @@ func (ec *executionContext) fieldContext_Query_animeBySeasonAndYear(ctx context.
 				return ec.fieldContext_Anime_anidbid(ctx, field)
 			case "thetvdbid":
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
+			case "sourceWorkId":
+				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -9024,6 +9107,8 @@ func (ec *executionContext) fieldContext_RelatedAnime_anime(ctx context.Context,
 				return ec.fieldContext_Anime_anidbid(ctx, field)
 			case "thetvdbid":
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
+			case "sourceWorkId":
+				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -9259,6 +9344,8 @@ func (ec *executionContext) fieldContext_StaffRole_anime(ctx context.Context, fi
 				return ec.fieldContext_Anime_anidbid(ctx, field)
 			case "thetvdbid":
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
+			case "sourceWorkId":
+				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -9543,6 +9630,8 @@ func (ec *executionContext) fieldContext_UserAnime_anime(ctx context.Context, fi
 				return ec.fieldContext_Anime_anidbid(ctx, field)
 			case "thetvdbid":
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
+			case "sourceWorkId":
+				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -11623,6 +11712,8 @@ func (ec *executionContext) _Anime(ctx context.Context, sel ast.SelectionSet, ob
 			out.Values[i] = ec._Anime_anidbid(ctx, field, obj)
 		case "thetvdbid":
 			out.Values[i] = ec._Anime_thetvdbid(ctx, field, obj)
+		case "sourceWorkId":
+			out.Values[i] = ec._Anime_sourceWorkId(ctx, field, obj)
 		case "slug":
 			out.Values[i] = ec._Anime_slug(ctx, field, obj)
 		case "titleEn":

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -17,6 +17,12 @@ type Anime struct {
 	Anidbid *string `json:"anidbid,omitempty"`
 	// TheTVDB ID of the anime
 	Thetvdbid *string `json:"thetvdbid,omitempty"`
+	// The work this anime adapts, when we know it -- the manga or novel, not the
+	// category `source` gives. Null for originals and for sources MyAnimeList's
+	// manga database does not cover, which together are most of the catalogue.
+	//
+	// Exposed because relatedAnime resolves SHARED_SOURCE from it.
+	SourceWorkID *string `json:"sourceWorkId,omitempty"`
 	// Public URL segment for the anime, e.g. "cowboy-bebop". Derived from the
 	// title, with a year and type appended only where several anime would
 	// otherwise claim the same slug. Null for records the backfill has not
@@ -373,16 +379,8 @@ func (e AirType) MarshalGQL(w io.Writer) {
 
 // The ways two anime can be connected.
 //
-// Only kinds we can actually establish appear here. Two more are wanted and are
-// absent because the data does not support them yet:
-//
-// A shared source work. Most anime adapt something, and the manga or novel is
-// what ties the adaptations together -- Fruits Basket in 2001 and 2019, Hunter x
-// Hunter in 1999 and 2011, Fullmetal Alchemist and Brotherhood. Those share no
-// TheTVDB series id and frequently no cast, so nothing else finds them. We record
-// `source` as a category ("Manga", "Light novel") and not as an identity, so we
-// know an anime came from a manga but never which one; this needs the work itself
-// modelled and anime pointed at it.
+// Only kinds we can actually establish appear here. One more is wanted and is
+// absent because the data does not support it yet:
 //
 // A shared creator, the thread joining Serial Experiments Lain and Haibane
 // Renmei. That needs staff credited against an anime by role, and anime_staff
@@ -393,15 +391,26 @@ const (
 	// Another entry in the same series: a season, film, OVA or special sharing
 	// its TheTVDB series id. The same show, not a different one.
 	AnimeRelationSameSeries AnimeRelation = "SAME_SERIES"
+	// A separate adaptation of the same source work -- Fruits Basket in 2001 and
+	// 2019, Hunter x Hunter in 1999 and 2011, Fullmetal Alchemist and
+	// Brotherhood.
+	//
+	// A different show, not another entry in one: these are distinct productions,
+	// often years and a studio apart, telling the same story again. They share no
+	// TheTVDB series id and frequently no cast, which is why SAME_SERIES cannot
+	// reach them and why the source work had to be modelled as an identity rather
+	// than the category `source` records.
+	AnimeRelationSharedSource AnimeRelation = "SHARED_SOURCE"
 )
 
 var AllAnimeRelation = []AnimeRelation{
 	AnimeRelationSameSeries,
+	AnimeRelationSharedSource,
 }
 
 func (e AnimeRelation) IsValid() bool {
 	switch e {
-	case AnimeRelationSameSeries:
+	case AnimeRelationSameSeries, AnimeRelationSharedSource:
 		return true
 	}
 	return false

--- a/graph/types.graphqls
+++ b/graph/types.graphqls
@@ -80,6 +80,15 @@ type Anime @key(fields: "id") {
     anidbid: String
     "TheTVDB ID of the anime"
     thetvdbid: String
+
+    """
+    The work this anime adapts, when we know it -- the manga or novel, not the
+    category `source` gives. Null for originals and for sources MyAnimeList's
+    manga database does not cover, which together are most of the catalogue.
+
+    Exposed because relatedAnime resolves SHARED_SOURCE from it.
+    """
+    sourceWorkId: String
     """
     Public URL segment for the anime, e.g. "cowboy-bebop". Derived from the
     title, with a year and type appended only where several anime would
@@ -176,16 +185,8 @@ type RelatedAnime {
 """
 The ways two anime can be connected.
 
-Only kinds we can actually establish appear here. Two more are wanted and are
-absent because the data does not support them yet:
-
-A shared source work. Most anime adapt something, and the manga or novel is
-what ties the adaptations together -- Fruits Basket in 2001 and 2019, Hunter x
-Hunter in 1999 and 2011, Fullmetal Alchemist and Brotherhood. Those share no
-TheTVDB series id and frequently no cast, so nothing else finds them. We record
-`source` as a category ("Manga", "Light novel") and not as an identity, so we
-know an anime came from a manga but never which one; this needs the work itself
-modelled and anime pointed at it.
+Only kinds we can actually establish appear here. One more is wanted and is
+absent because the data does not support it yet:
 
 A shared creator, the thread joining Serial Experiments Lain and Haibane
 Renmei. That needs staff credited against an anime by role, and anime_staff
@@ -197,6 +198,19 @@ enum AnimeRelation {
     its TheTVDB series id. The same show, not a different one.
     """
     SAME_SERIES
+
+    """
+    A separate adaptation of the same source work -- Fruits Basket in 2001 and
+    2019, Hunter x Hunter in 1999 and 2011, Fullmetal Alchemist and
+    Brotherhood.
+
+    A different show, not another entry in one: these are distinct productions,
+    often years and a studio apart, telling the same story again. They share no
+    TheTVDB series id and frequently no cast, which is why SAME_SERIES cannot
+    reach them and why the source work had to be modelled as an identity rather
+    than the category `source` records.
+    """
+    SHARED_SOURCE
 }
 
 type AnimeSeason {

--- a/graph/types.resolvers.go
+++ b/graph/types.resolvers.go
@@ -115,7 +115,7 @@ func (r *animeResolver) Seasons(ctx context.Context, obj *model.Anime) ([]*model
 
 // RelatedAnime is the resolver for the relatedAnime field.
 func (r *animeResolver) RelatedAnime(ctx context.Context, obj *model.Anime, limit *int) ([]*model.RelatedAnime, error) {
-	return resolvers.RelatedAnimeBySeries(ctx, r.AnimeService, obj, limit)
+	return resolvers.RelatedAnimeFor(ctx, r.AnimeService, obj, limit)
 }
 
 // NextEpisode is the resolver for the nextEpisode field.

--- a/internal/db/repositories/anime/anime_entity.go
+++ b/internal/db/repositories/anime/anime_entity.go
@@ -10,6 +10,9 @@ type Anime struct {
 	AnidbID       *string      `gorm:"column:anidbid;null" json:"anidbid"`
 	MalID         *int         `gorm:"column:mal_id;null" json:"mal_id"`
 	TheTVDBID     *string      `gorm:"column:thetvdbid;null" json:"thetvdbid"`
+	// The work this anime adapts, when known. Null for originals and for
+	// sources MAL does not cover, which is most of the catalogue.
+	SourceWorkID  *string      `gorm:"column:source_work_id;null" json:"source_work_id"`
 	// UrlSlug is the public URL segment, generated in postgres and carried
 	// here by CDC. Nullable while the backfill is still in flight.
 	UrlSlug       *string      `gorm:"column:url_slug;null" json:"url_slug"`
@@ -50,6 +53,9 @@ type AnimeWithNextEpisode struct {
 	AnidbID       *string                    `gorm:"column:anidbid;null" json:"anidbid"`
 	MalID         *int                       `gorm:"column:mal_id;null" json:"mal_id"`
 	TheTVDBID     *string                    `gorm:"column:thetvdbid;null" json:"thetvdbid"`
+	// The work this anime adapts, when known. Null for originals and for
+	// sources MAL does not cover, which is most of the catalogue.
+	SourceWorkID  *string      `gorm:"column:source_work_id;null" json:"source_work_id"`
 	UrlSlug       *string                    `gorm:"column:url_slug;null" json:"url_slug"`
 	Type          *RECORD_TYPE               `gorm:"column:type;type:text;default:Anime" json:"type"`
 	TitleEn       *string                    `gorm:"column:title_en;null" json:"title_en"`

--- a/internal/db/repositories/anime/anime_entity.go
+++ b/internal/db/repositories/anime/anime_entity.go
@@ -6,13 +6,13 @@ import (
 )
 
 type Anime struct {
-	ID            string       `gorm:"column:id;type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
-	AnidbID       *string      `gorm:"column:anidbid;null" json:"anidbid"`
-	MalID         *int         `gorm:"column:mal_id;null" json:"mal_id"`
-	TheTVDBID     *string      `gorm:"column:thetvdbid;null" json:"thetvdbid"`
+	ID        string  `gorm:"column:id;type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	AnidbID   *string `gorm:"column:anidbid;null" json:"anidbid"`
+	MalID     *int    `gorm:"column:mal_id;null" json:"mal_id"`
+	TheTVDBID *string `gorm:"column:thetvdbid;null" json:"thetvdbid"`
 	// The work this anime adapts, when known. Null for originals and for
 	// sources MAL does not cover, which is most of the catalogue.
-	SourceWorkID  *string      `gorm:"column:source_work_id;null" json:"source_work_id"`
+	SourceWorkID *string `gorm:"column:source_work_id;null" json:"source_work_id"`
 	// UrlSlug is the public URL segment, generated in postgres and carried
 	// here by CDC. Nullable while the backfill is still in flight.
 	UrlSlug       *string      `gorm:"column:url_slug;null" json:"url_slug"`
@@ -53,9 +53,7 @@ type AnimeWithNextEpisode struct {
 	AnidbID       *string                    `gorm:"column:anidbid;null" json:"anidbid"`
 	MalID         *int                       `gorm:"column:mal_id;null" json:"mal_id"`
 	TheTVDBID     *string                    `gorm:"column:thetvdbid;null" json:"thetvdbid"`
-	// The work this anime adapts, when known. Null for originals and for
-	// sources MAL does not cover, which is most of the catalogue.
-	SourceWorkID  *string      `gorm:"column:source_work_id;null" json:"source_work_id"`
+	SourceWorkID  *string                    `gorm:"column:source_work_id;null" json:"source_work_id"`
 	UrlSlug       *string                    `gorm:"column:url_slug;null" json:"url_slug"`
 	Type          *RECORD_TYPE               `gorm:"column:type;type:text;default:Anime" json:"type"`
 	TitleEn       *string                    `gorm:"column:title_en;null" json:"title_en"`

--- a/internal/db/repositories/anime/anime_repository.go
+++ b/internal/db/repositories/anime/anime_repository.go
@@ -36,6 +36,7 @@ type AnimeRepositoryImpl interface {
 	FindBySlug(ctx context.Context, slug string) (*Anime, error)
 	FindByIDs(ctx context.Context, ids []string) ([]*Anime, error)
 	FindBySeriesID(ctx context.Context, seriesID string, excludeID string, limit int) ([]*Anime, error)
+	FindBySourceWorkID(ctx context.Context, workID string, excludeID string, limit int) ([]*Anime, error)
 	FindByIDsWithEpisodes(ctx context.Context, ids []string) ([]*Anime, error)
 	FindByName(ctx context.Context, name string) ([]*Anime, error)
 	FindByNameWithEpisodes(ctx context.Context, name string) ([]*Anime, error)
@@ -988,6 +989,43 @@ func (a *AnimeRepository) FindByIDs(ctx context.Context, ids []string) ([]*Anime
 
 	var animes []*Anime
 	err := a.db.DB.WithContext(ctx).Where("id IN ?", ids).Find(&animes).Error
+	if err != nil {
+		metrics.GetAppMetrics().DatabaseSince(startTime, "anime", metrics.MethodSelect, metrics.Error)
+		return nil, err
+	}
+
+	metrics.GetAppMetrics().DatabaseSince(startTime, "anime", metrics.MethodSelect, metrics.Success)
+	return animes, nil
+}
+
+// FindBySourceWorkID returns the other anime adapted from the same work,
+// oldest first with undated entries last.
+//
+// This is the signal TheTVDB cannot provide. Re-adaptations of one manga are
+// separate productions years apart -- Fruits Basket in 2001 and 2019, Hunter x
+// Hunter in 1999 and 2011 -- so they carry different series ids and usually a
+// different cast. The source work is what they actually share.
+//
+// The empty-string guard matters for the same reason it does on series id:
+// source_work_id is nullable, and '' = '' is true, so a blank value would
+// relate every blank-valued anime to every other one and look like a working
+// feature.
+//
+// Served by idx_anime_source_work_id from migration 000063.
+func (a *AnimeRepository) FindBySourceWorkID(ctx context.Context, workID string, excludeID string, limit int) ([]*Anime, error) {
+	startTime := time.Now()
+
+	if workID == "" {
+		return []*Anime{}, nil
+	}
+
+	var animes []*Anime
+	err := a.db.DB.WithContext(ctx).
+		Where("source_work_id = ? AND id <> ?", workID, excludeID).
+		Order("start_date IS NULL, start_date ASC").
+		Limit(limit).
+		Find(&animes).Error
+
 	if err != nil {
 		metrics.GetAppMetrics().DatabaseSince(startTime, "anime", metrics.MethodSelect, metrics.Error)
 		return nil, err

--- a/internal/db/repositories/anime/field_selection.go
+++ b/internal/db/repositories/anime/field_selection.go
@@ -37,6 +37,7 @@ func (fs *FieldSelection) BuildSelectClause(tableName string) string {
 		"id":            "id",
 		"anidbid":       "anidbid",
 		"thetvdbid":     "thetvdbid",
+		"sourceWorkId":  "source_work_id",
 		// Unmapped fields are silently dropped from the SELECT, so a field
 		// missing here comes back null with no error anywhere -- which is how
 		// animeBySeasons served slug: null while every other resolver worked.

--- a/internal/resolvers/anime.go
+++ b/internal/resolvers/anime.go
@@ -123,6 +123,7 @@ func transformAnimeToGraphQL(animeEntity anime2.Anime) (*model.Anime, error) {
 		ID:            animeEntity.ID,
 		Anidbid:       animeEntity.AnidbID,
 		Thetvdbid:     animeEntity.TheTVDBID,
+		SourceWorkID:  animeEntity.SourceWorkID,
 		Slug:          animeEntity.UrlSlug,
 		Type:          recordTypeToString(animeEntity.Type),
 		MalID:         animeEntity.MalID,
@@ -230,6 +231,7 @@ func transformAnimeToGraphQLWithEpisode(animeEntity anime2.AnimeWithNextEpisode)
 		ID:            animeEntity.ID,
 		Anidbid:       animeEntity.AnidbID,
 		Thetvdbid:     animeEntity.TheTVDBID,
+		SourceWorkID:  animeEntity.SourceWorkID,
 		Slug:          animeEntity.UrlSlug,
 		Type:          recordTypeToString(animeEntity.Type),
 		MalID:         animeEntity.MalID,
@@ -714,61 +716,95 @@ func DBSearchAnime(ctx context.Context, animeService anime.AnimeServiceImpl, que
 	return animes, nil
 }
 
-// RelatedAnimeBySeries resolves Anime.relatedAnime: the other entries sharing
-// this anime's TheTVDB series id.
+// RelatedAnimeFor resolves Anime.relatedAnime from every signal we have.
+//
+// Two, currently. Sharing a TheTVDB series id means the same show -- a season,
+// film or special. Sharing a source work means a separate adaptation of the
+// same story: Fruits Basket in 2001 and 2019, Hunter x Hunter in 1999 and
+// 2011. Those carry different series ids and usually a different cast, which
+// is exactly why the first signal cannot reach them.
+//
+// Series matches are gathered first and win any tie. An anime can legitimately
+// match both -- the seasons of one adaptation share a series id and a source
+// work -- and "another entry in this series" is the more specific truth about
+// such a pair than "a separate adaptation".
 //
 // A default limit rather than none, because the groups are not uniformly small
-// -- the largest in the catalogue holds 78 anime, and a Pokemon page returning
-// all of them would be a wall of links and a much larger response than the
-// caller expected.
-func RelatedAnimeBySeries(ctx context.Context, animeService anime.AnimeServiceImpl, obj *model.Anime, limit *int) ([]*model.RelatedAnime, error) {
+// -- the largest series in the catalogue holds 78 anime, and a Pokemon page
+// returning all of them would be a wall of links and a much larger response
+// than the caller expected.
+func RelatedAnimeFor(ctx context.Context, animeService anime.AnimeServiceImpl, obj *model.Anime, limit *int) ([]*model.RelatedAnime, error) {
 	tracer := tracing.GetTracer(ctx)
-	ctx, span := tracer.Start(ctx, "RelatedAnimeBySeries",
+	ctx, span := tracer.Start(ctx, "RelatedAnimeFor",
 		trace.WithAttributes(
 			attribute.String("anime.id", obj.ID),
-			attribute.String("resolver.name", "RelatedAnimeBySeries"),
+			attribute.String("resolver.name", "RelatedAnimeFor"),
 		),
 		tracing.GetEnvironmentAttribute(),
 	)
 	defer span.End()
-
-	// No series id means nothing to group on. Not an error: most of the
-	// catalogue has never been enriched with one.
-	if obj.Thetvdbid == nil || *obj.Thetvdbid == "" {
-		span.SetAttributes(attribute.Bool("anime.has_series_id", false))
-		return []*model.RelatedAnime{}, nil
-	}
 
 	resultLimit := 25
 	if limit != nil && *limit > 0 {
 		resultLimit = *limit
 	}
 
-	found, err := animeService.RelatedAnimeBySeriesID(ctx, *obj.Thetvdbid, obj.ID, resultLimit)
-	if err != nil {
-		span.RecordError(err)
-		return nil, err
+	related := make([]*model.RelatedAnime, 0, resultLimit)
+	// The anime itself is excluded by the queries, but it also guards against a
+	// row pointing at its own work being counted twice.
+	seen := map[string]bool{obj.ID: true}
+
+	appendFound := func(found []*anime2.Anime, relation model.AnimeRelation) error {
+		for _, entity := range found {
+			if entity == nil || seen[entity.ID] {
+				continue
+			}
+			if len(related) >= resultLimit {
+				return nil
+			}
+			transformed, err := transformAnimeToGraphQL(*entity)
+			if err != nil {
+				span.RecordError(err)
+				return err
+			}
+			seen[entity.ID] = true
+			// Carried per entry rather than per list: the two signals return
+			// different kinds from the same call.
+			related = append(related, &model.RelatedAnime{
+				Anime:    transformed,
+				Relation: relation,
+			})
+		}
+		return nil
 	}
 
-	related := make([]*model.RelatedAnime, 0, len(found))
-	for _, entity := range found {
-		if entity == nil {
-			continue
-		}
-		transformed, err := transformAnimeToGraphQL(*entity)
+	// No series id means nothing to group on. Not an error: most of the
+	// catalogue has never been enriched with one.
+	hasSeries := obj.Thetvdbid != nil && *obj.Thetvdbid != ""
+	if hasSeries {
+		found, err := animeService.RelatedAnimeBySeriesID(ctx, *obj.Thetvdbid, obj.ID, resultLimit)
 		if err != nil {
 			span.RecordError(err)
 			return nil, err
 		}
-		// Everything this resolver finds is found the same way, so the kind is
-		// constant here. It is carried per entry rather than per list because
-		// the next signal will not be: matching on shared cast or a shared
-		// creator will return entries of a different kind from the same query.
-		related = append(related, &model.RelatedAnime{
-			Anime:    transformed,
-			Relation: model.AnimeRelationSameSeries,
-		})
+		if err := appendFound(found, model.AnimeRelationSameSeries); err != nil {
+			return nil, err
+		}
 	}
+	span.SetAttributes(attribute.Bool("anime.has_series_id", hasSeries))
+
+	hasWork := obj.SourceWorkID != nil && *obj.SourceWorkID != ""
+	if hasWork && len(related) < resultLimit {
+		found, err := animeService.RelatedAnimeBySourceWorkID(ctx, *obj.SourceWorkID, obj.ID, resultLimit)
+		if err != nil {
+			span.RecordError(err)
+			return nil, err
+		}
+		if err := appendFound(found, model.AnimeRelationSharedSource); err != nil {
+			return nil, err
+		}
+	}
+	span.SetAttributes(attribute.Bool("anime.has_source_work", hasWork))
 
 	span.SetAttributes(attribute.Int("anime.related_count", len(related)))
 	return related, nil

--- a/internal/services/anime/anime.go
+++ b/internal/services/anime/anime.go
@@ -16,6 +16,7 @@ type AnimeServiceImpl interface {
 	AnimeByIDWithEpisodes(ctx context.Context, id string) (*anime.Anime, error)
 	AnimeByIDs(ctx context.Context, ids []string) ([]*anime.Anime, error)
 	RelatedAnimeBySeriesID(ctx context.Context, seriesID string, excludeID string, limit int) ([]*anime.Anime, error)
+	RelatedAnimeBySourceWorkID(ctx context.Context, workID string, excludeID string, limit int) ([]*anime.Anime, error)
 	AnimeByIDsWithEpisodes(ctx context.Context, ids []string) ([]*anime.Anime, error)
 	TopRatedAnime(ctx context.Context, limit int) ([]*anime.Anime, error)
 	TopRatedAnimeWithEpisodes(ctx context.Context, limit int) ([]*anime.Anime, error)
@@ -262,4 +263,11 @@ func (a *AnimeService) RelatedAnimeBySeriesID(ctx context.Context, seriesID stri
 	defer span.End()
 
 	return a.Repository.FindBySeriesID(ctx, seriesID, excludeID, limit)
+}
+
+func (a *AnimeService) RelatedAnimeBySourceWorkID(ctx context.Context, workID string, excludeID string, limit int) ([]*anime.Anime, error) {
+	ctx, span := a.startServiceSpan(ctx, "RelatedAnimeBySourceWorkID")
+	defer span.End()
+
+	return a.Repository.FindBySourceWorkID(ctx, workID, excludeID, limit)
 }


### PR DESCRIPTION
Steps 7 and 8 of `docs/manga-and-works.md` (in anime_scraper), read-store side. The `AnimeRelation` enum's own doc comment has described this gap since it was written — this fills it and rewrites the comment.

## What it enables

`anime.source` records a **category**, never an identity — we knew 6,110 anime came from "Manga" and never which one. So re-adaptations of the same story have looked unrelated:

```
Fruits Basket        2001  and  2019
Hunter x Hunter      1999  and  2011
Fullmetal Alchemist  2003  and  Brotherhood
```

Different TheTVDB series ids, usually different casts — which is exactly why `SAME_SERIES` can't reach them. The source work is the only thing connecting them.

## Changes

- **Migration 000063** — `work` table beside `anime`, plus `anime.source_work_id` (nullable, indexed).
- **`FindBySourceWorkID`** — sibling of `FindBySeriesID`, same empty-string guard. That guard is load-bearing: `source_work_id` is nullable, `'' = ''` is true, and without it every blank-valued anime would relate to every other one and *look like a working feature*.
- **`RelatedAnimeFor`** replaces `RelatedAnimeBySeries` — gathers both signals, dedupes, series first.
- **`SHARED_SOURCE`** added to `AnimeRelation`; `sourceWorkId` exposed on `Anime`.

## Two decisions worth reviewing

**`varchar(36)`, not `uuid` or `char(36)`.** Migration 000062 exists precisely because four `char(36)` columns forced a cast that made their indexes unusable — 37,000 sequential scans on a 450k-row table. A `uuid` column here would reproduce that against `anime.source_work_id`.

**Series matches win ties.** An anime can legitimately match both signals — the seasons of one adaptation share a series id *and* a source work. "Another entry in this series" is the more specific truth about such a pair than "a separate adaptation", so `SAME_SERIES` is gathered first and `SHARED_SOURCE` skips anything already seen.

**No foreign key**, matching the scraper. CDC makes no ordering promise across tables, an anime routinely arrives before the work it points at, and `anime-sync` already discards FK violations for that reason.

## Verified

`go build ./...` passes; gqlgen regenerated cleanly. `go vet` reports 2 failures in `air_time_test.go` and `anime_season_optimized_test.go` — **both pre-existing on `main`** (confirmed by running vet on `origin/main`: same count). `MockAnimeService` doesn't implement `RelatedAnimeBySeriesID` either, so it was already incomplete; I left it rather than expand scope.

## Not yet wired

This is the read *store*. Nothing populates `anime.source_work_id` there until `anime-sync` carries the column — it maps CDC fields explicitly in both its payload struct and its entity, so it needs a change too, plus a consumer for `anime-db.public.work`. That's the next PR. Until then this resolves to an empty list, which is the existing behaviour.

**Ordering:** migration 000063 must apply before this code deploys — the entity selects `source_work_id`. The versioned migration Job handles that.
