### PR TITLE
feat: give the read store work.url_slug and a float score

### DIFF
--- a/.github/workflows/migrations.yaml
+++ b/.github/workflows/migrations.yaml
@@ -80,8 +80,8 @@ jobs:
 
             SELECT count(*) INTO n FROM information_schema.columns
               WHERE table_schema = 'public' AND table_name <> 'schema_migrations';
-            IF n <> 179 THEN
-              RAISE EXCEPTION 'expected 179 columns, found %', n;
+            IF n <> 180 THEN
+              RAISE EXCEPTION 'expected 180 columns, found %', n;
             END IF;
 
             -- Three episode-count triggers plus ten updated_at triggers.

--- a/db/migrations/000064_work_slug_and_score.down.sql
+++ b/db/migrations/000064_work_slug_and_score.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "work" ALTER COLUMN "score" TYPE numeric(4,2);
+DROP INDEX IF EXISTS "idx_work_url_slug";
+ALTER TABLE "work" DROP COLUMN IF EXISTS "url_slug";

--- a/db/migrations/000064_work_slug_and_score.up.sql
+++ b/db/migrations/000064_work_slug_and_score.up.sql
@@ -1,0 +1,24 @@
+-- Brings the read store's `work` into line with the scraper's, which gained a
+-- url_slug and changed score's type after 000063 landed.
+--
+-- url_slug is the public URL segment behind /manga/<slug>. It is assigned by a
+-- trigger in the scraper and never recomputed, so a title correction upstream
+-- cannot silently move a live URL. No trigger is needed here: this side only
+-- ever receives the value the scraper already decided, and generating a second
+-- one would produce a different slug for the same work.
+ALTER TABLE "work" ADD COLUMN IF NOT EXISTS "url_slug" varchar(255);
+
+-- Unique because it is a URL. Nullable rows do not collide under a unique index
+-- in postgres, so rows that arrive before the scraper has assigned one sit
+-- happily alongside each other.
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_work_url_slug" ON "work" ("url_slug");
+
+-- double precision, matching the scraper.
+--
+-- Debezium's decimal.handling.mode defaults to `precise`, which encodes numeric
+-- columns as base64 bytes and a scale rather than as a number. The consumer
+-- reads this into a float, so the column has to be a float on both sides --
+-- see anime_scraper migration 1787360400000 for the full reasoning.
+--
+-- Empty table, so the type change rewrites nothing.
+ALTER TABLE "work" ALTER COLUMN "score" TYPE double precision;


### PR DESCRIPTION
Brings the read store's `work` into line with the scraper's, which gained `url_slug` (#18) and changed `score`'s type (#19) after 000063 landed. Applies automatically via the versioned migration Job at sync-wave 0.

## Changes

- **`url_slug`** + unique index — the segment behind `/manga/<slug>`. **No trigger on this side**: the scraper assigns the slug and never recomputes it, and generating a second one here would produce a *different* slug for the same work.
- **`score` → `double precision`** — Debezium's `decimal.handling.mode` defaults to `precise`, which encodes `numeric` as base64 bytes plus a scale, not a number. The consumer reads a float, so both ends must be floats. `work.score` was the only numeric column in the scraper schema, which is why nothing needed this before.
- **Schema assertion 179 → 180 columns.**

## Verified against Postgres 16

Ran the real chain rather than reasoning about it:

```
up   -> 64/u work_slug_and_score
        tables=15  columns=180        <- matches the bumped assertion
        work.score    double precision
        work.url_slug character varying
down -all -> tables remaining=0
up   -> re-applies cleanly
```

That assertion is the guard that caught 000063 — *"a migration that applies is not the same as a migration that produced the schema it was supposed to"* — so I checked the number against a real run instead of counting by hand.