### PR TITLE
feat: expose source works through the API

### DIFF
--- a/graph/generated/generated.go
+++ b/graph/generated/generated.go
@@ -45,6 +45,7 @@ type ResolverRoot interface {
 	Episode() EpisodeResolver
 	Query() QueryResolver
 	UserAnime() UserAnimeResolver
+	Work() WorkResolver
 }
 
 type DirectiveRoot struct {
@@ -76,6 +77,7 @@ type ComplexityRoot struct {
 		Seasons            func(childComplexity int) int
 		Slug               func(childComplexity int) int
 		Source             func(childComplexity int) int
+		SourceWork         func(childComplexity int) int
 		SourceWorkID       func(childComplexity int) int
 		StartDate          func(childComplexity int) int
 		StreamingPlatforms func(childComplexity int) int
@@ -212,6 +214,7 @@ type ComplexityRoot struct {
 		Staff                       func(childComplexity int, id string) int
 		StaffBySlug                 func(childComplexity int, slug string) int
 		TopRatedAnime               func(childComplexity int, limit *int) int
+		WorkBySlug                  func(childComplexity int, slug string) int
 		__resolve__service          func(childComplexity int) int
 		__resolve_entities          func(childComplexity int, representations []map[string]interface{}) int
 	}
@@ -237,12 +240,41 @@ type ComplexityRoot struct {
 		AnimeID func(childComplexity int) int
 	}
 
+	Work struct {
+		Adaptations   func(childComplexity int, limit *int) int
+		Authors       func(childComplexity int) int
+		Chapters      func(childComplexity int) int
+		CreatedAt     func(childComplexity int) int
+		Demographic   func(childComplexity int) int
+		Favorites     func(childComplexity int) int
+		ID            func(childComplexity int) int
+		ImageURL      func(childComplexity int) int
+		MalID         func(childComplexity int) int
+		Members       func(childComplexity int) int
+		PublishedFrom func(childComplexity int) int
+		PublishedTo   func(childComplexity int) int
+		Ranking       func(childComplexity int) int
+		Score         func(childComplexity int) int
+		Serialization func(childComplexity int) int
+		Status        func(childComplexity int) int
+		Synopsis      func(childComplexity int) int
+		TitleEn       func(childComplexity int) int
+		TitleJp       func(childComplexity int) int
+		TitleSynonyms func(childComplexity int) int
+		Type          func(childComplexity int) int
+		URLSlug       func(childComplexity int) int
+		UpdatedAt     func(childComplexity int) int
+		Volumes       func(childComplexity int) int
+	}
+
 	_Service struct {
 		SDL func(childComplexity int) int
 	}
 }
 
 type AnimeResolver interface {
+	SourceWork(ctx context.Context, obj *model.Anime) (*model.Work, error)
+
 	Tags(ctx context.Context, obj *model.Anime) ([]string, error)
 
 	Episodes(ctx context.Context, obj *model.Anime) ([]*model.Episode, error)
@@ -286,9 +318,13 @@ type QueryResolver interface {
 	CharactersAndStaffByAnimeID(ctx context.Context, animeID string) ([]*model.CharacterWithStaff, error)
 	Staff(ctx context.Context, id string) (*model.AnimeStaff, error)
 	StaffBySlug(ctx context.Context, slug string) (*model.AnimeStaff, error)
+	WorkBySlug(ctx context.Context, slug string) (*model.Work, error)
 }
 type UserAnimeResolver interface {
 	Anime(ctx context.Context, obj *model.UserAnime) (*model.Anime, error)
+}
+type WorkResolver interface {
+	Adaptations(ctx context.Context, obj *model.Work, limit *int) ([]*model.Anime, error)
 }
 
 type executableSchema struct {
@@ -464,6 +500,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Anime.Source(childComplexity), true
+
+	case "Anime.sourceWork":
+		if e.complexity.Anime.SourceWork == nil {
+			break
+		}
+
+		return e.complexity.Anime.SourceWork(childComplexity), true
 
 	case "Anime.sourceWorkId":
 		if e.complexity.Anime.SourceWorkID == nil {
@@ -1250,6 +1293,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.TopRatedAnime(childComplexity, args["limit"].(*int)), true
 
+	case "Query.workBySlug":
+		if e.complexity.Query.WorkBySlug == nil {
+			break
+		}
+
+		args, err := ec.field_Query_workBySlug_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.WorkBySlug(childComplexity, args["slug"].(string)), true
+
 	case "Query._service":
 		if e.complexity.Query.__resolve__service == nil {
 			break
@@ -1331,6 +1386,179 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.UserAnime.AnimeID(childComplexity), true
+
+	case "Work.adaptations":
+		if e.complexity.Work.Adaptations == nil {
+			break
+		}
+
+		args, err := ec.field_Work_adaptations_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Work.Adaptations(childComplexity, args["limit"].(*int)), true
+
+	case "Work.authors":
+		if e.complexity.Work.Authors == nil {
+			break
+		}
+
+		return e.complexity.Work.Authors(childComplexity), true
+
+	case "Work.chapters":
+		if e.complexity.Work.Chapters == nil {
+			break
+		}
+
+		return e.complexity.Work.Chapters(childComplexity), true
+
+	case "Work.createdAt":
+		if e.complexity.Work.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.Work.CreatedAt(childComplexity), true
+
+	case "Work.demographic":
+		if e.complexity.Work.Demographic == nil {
+			break
+		}
+
+		return e.complexity.Work.Demographic(childComplexity), true
+
+	case "Work.favorites":
+		if e.complexity.Work.Favorites == nil {
+			break
+		}
+
+		return e.complexity.Work.Favorites(childComplexity), true
+
+	case "Work.id":
+		if e.complexity.Work.ID == nil {
+			break
+		}
+
+		return e.complexity.Work.ID(childComplexity), true
+
+	case "Work.imageUrl":
+		if e.complexity.Work.ImageURL == nil {
+			break
+		}
+
+		return e.complexity.Work.ImageURL(childComplexity), true
+
+	case "Work.malId":
+		if e.complexity.Work.MalID == nil {
+			break
+		}
+
+		return e.complexity.Work.MalID(childComplexity), true
+
+	case "Work.members":
+		if e.complexity.Work.Members == nil {
+			break
+		}
+
+		return e.complexity.Work.Members(childComplexity), true
+
+	case "Work.publishedFrom":
+		if e.complexity.Work.PublishedFrom == nil {
+			break
+		}
+
+		return e.complexity.Work.PublishedFrom(childComplexity), true
+
+	case "Work.publishedTo":
+		if e.complexity.Work.PublishedTo == nil {
+			break
+		}
+
+		return e.complexity.Work.PublishedTo(childComplexity), true
+
+	case "Work.ranking":
+		if e.complexity.Work.Ranking == nil {
+			break
+		}
+
+		return e.complexity.Work.Ranking(childComplexity), true
+
+	case "Work.score":
+		if e.complexity.Work.Score == nil {
+			break
+		}
+
+		return e.complexity.Work.Score(childComplexity), true
+
+	case "Work.serialization":
+		if e.complexity.Work.Serialization == nil {
+			break
+		}
+
+		return e.complexity.Work.Serialization(childComplexity), true
+
+	case "Work.status":
+		if e.complexity.Work.Status == nil {
+			break
+		}
+
+		return e.complexity.Work.Status(childComplexity), true
+
+	case "Work.synopsis":
+		if e.complexity.Work.Synopsis == nil {
+			break
+		}
+
+		return e.complexity.Work.Synopsis(childComplexity), true
+
+	case "Work.titleEn":
+		if e.complexity.Work.TitleEn == nil {
+			break
+		}
+
+		return e.complexity.Work.TitleEn(childComplexity), true
+
+	case "Work.titleJp":
+		if e.complexity.Work.TitleJp == nil {
+			break
+		}
+
+		return e.complexity.Work.TitleJp(childComplexity), true
+
+	case "Work.titleSynonyms":
+		if e.complexity.Work.TitleSynonyms == nil {
+			break
+		}
+
+		return e.complexity.Work.TitleSynonyms(childComplexity), true
+
+	case "Work.type":
+		if e.complexity.Work.Type == nil {
+			break
+		}
+
+		return e.complexity.Work.Type(childComplexity), true
+
+	case "Work.urlSlug":
+		if e.complexity.Work.URLSlug == nil {
+			break
+		}
+
+		return e.complexity.Work.URLSlug(childComplexity), true
+
+	case "Work.updatedAt":
+		if e.complexity.Work.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.Work.UpdatedAt(childComplexity), true
+
+	case "Work.volumes":
+		if e.complexity.Work.Volumes == nil {
+			break
+		}
+
+		return e.complexity.Work.Volumes(childComplexity), true
 
 	case "_Service.sdl":
 		if e.complexity._Service.SDL == nil {
@@ -1503,6 +1731,15 @@ type Query {
     staff(id: ID!): AnimeStaff
     "Look a staff member up by their public URL slug. Null when no one claims it."
     staffBySlug(slug: String!): AnimeStaff
+    """
+    Look a source work up by its public URL slug -- the manga, light novel or
+    novel behind /manga/<slug>. Null when no work claims it.
+
+    One query for the whole family rather than one per type, because they are
+    one table discriminated by ` + "`" + `type` + "`" + `, exactly as MyAnimeList serves them from
+    a single namespace.
+    """
+    workBySlug(slug: String!): Work
 }
 `, BuiltIn: false},
 	{Name: "../types.graphqls", Input: `# Season is now a string scalar that can accept any season format
@@ -1596,6 +1833,13 @@ type Anime @key(fields: "id") {
     Exposed because relatedAnime resolves SHARED_SOURCE from it.
     """
     sourceWorkId: String
+
+    """
+    The work this anime adapts, resolved. Null for originals and for sources
+    MyAnimeList's manga database does not cover, which together are most of the
+    catalogue.
+    """
+    sourceWork: Work @goField(forceResolver: true)
     """
     Public URL segment for the anime, e.g. "cowboy-bebop". Derived from the
     title, with a year and type appended only where several anime would
@@ -1676,6 +1920,82 @@ type Anime @key(fields: "id") {
     createdAt: String!
     updatedAt: String!
     nextEpisode: Episode @goField(forceResolver: true )
+}
+
+"""
+A source work: the manga, light novel or novel an anime is adapted from.
+
+One type for the whole family, discriminated by ` + "`" + `type` + "`" + `. MyAnimeList serves them
+from a single namespace at /manga/<id> and their fields are identical apart from
+demographic, so splitting them into separate types would mean near-copies and a
+caller having to guess which to ask for.
+
+The public URL follows the same reasoning: /manga/<slug> for all of them, with
+the type shown on the page. ` + "`" + `type` + "`" + ` is data that can be corrected upstream, and a
+URL that moved when a work was reclassified would break every link to it.
+"""
+type Work {
+    id: ID!
+
+    "MyAnimeList's id for this work. Null for works from any other source."
+    malId: Int
+
+    """
+    Which kind of work this is: MANGA, LIGHT_NOVEL, NOVEL, WEB_MANGA,
+    WEB_NOVEL, ONE_SHOT, DOUJINSHI, MANHWA, MANHUA or FOUR_KOMA.
+
+    A plain string rather than an enum: MyAnimeList adds labels without warning,
+    and an unrecognised one should render as itself rather than fail the query.
+    """
+    type: String!
+
+    "Public URL segment. Assigned once and never rewritten."
+    urlSlug: String
+
+    titleEn: String
+    titleJp: String
+    titleSynonyms: [String!]
+    synopsis: String
+    imageUrl: String
+
+    "Publication status as the source reports it."
+    status: String
+    volumes: Int
+    chapters: Int
+    publishedFrom: String
+    publishedTo: String
+
+    "Target readership -- Shounen, Seinen, Josei. Absent on light novels."
+    demographic: String
+
+    "The magazine it ran in, when it ran in one."
+    serialization: String
+
+    "Credited authors, surname first as the source writes them."
+    authors: [String!]
+
+    score: Float
+    ranking: Int
+    members: Int
+    favorites: Int
+
+    """
+    Every anime adapted from this work, oldest first.
+
+    This is the point of modelling works at all: Fruits Basket in 2001 and 2019,
+    Hunter x Hunter in 1999 and 2011. Those share no TheTVDB series id and often
+    no cast, so nothing else relates them to each other.
+
+    Usually empty, and increasingly so. MyAnimeList holds over sixty thousand
+    manga against roughly ten thousand anime adapted from one, so most works
+    have never been adapted and never will be. Empty is the ordinary case here,
+    not a missing relation -- a page rendering this needs a real empty state
+    rather than an apology.
+    """
+    adaptations(limit: Int): [Anime!] @goField(forceResolver: true)
+
+    createdAt: String!
+    updatedAt: String!
 }
 
 """
@@ -2356,6 +2676,36 @@ func (ec *executionContext) field_Query_topRatedAnime_args(ctx context.Context, 
 	return args, nil
 }
 
+func (ec *executionContext) field_Query_workBySlug_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["slug"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("slug"))
+		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["slug"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Work_adaptations_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *int
+	if tmp, ok := rawArgs["limit"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("limit"))
+		arg0, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["limit"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) field___Type_enumValues_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -2556,6 +2906,97 @@ func (ec *executionContext) fieldContext_Anime_sourceWorkId(ctx context.Context,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Anime_sourceWork(ctx context.Context, field graphql.CollectedField, obj *model.Anime) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Anime_sourceWork(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Anime().SourceWork(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Work)
+	fc.Result = res
+	return ec.marshalOWork2ᚖgithubᚗcomᚋweebᚑvipᚋanimeᚑapiᚋgraphᚋmodelᚐWork(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Anime_sourceWork(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Anime",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Work_id(ctx, field)
+			case "malId":
+				return ec.fieldContext_Work_malId(ctx, field)
+			case "type":
+				return ec.fieldContext_Work_type(ctx, field)
+			case "urlSlug":
+				return ec.fieldContext_Work_urlSlug(ctx, field)
+			case "titleEn":
+				return ec.fieldContext_Work_titleEn(ctx, field)
+			case "titleJp":
+				return ec.fieldContext_Work_titleJp(ctx, field)
+			case "titleSynonyms":
+				return ec.fieldContext_Work_titleSynonyms(ctx, field)
+			case "synopsis":
+				return ec.fieldContext_Work_synopsis(ctx, field)
+			case "imageUrl":
+				return ec.fieldContext_Work_imageUrl(ctx, field)
+			case "status":
+				return ec.fieldContext_Work_status(ctx, field)
+			case "volumes":
+				return ec.fieldContext_Work_volumes(ctx, field)
+			case "chapters":
+				return ec.fieldContext_Work_chapters(ctx, field)
+			case "publishedFrom":
+				return ec.fieldContext_Work_publishedFrom(ctx, field)
+			case "publishedTo":
+				return ec.fieldContext_Work_publishedTo(ctx, field)
+			case "demographic":
+				return ec.fieldContext_Work_demographic(ctx, field)
+			case "serialization":
+				return ec.fieldContext_Work_serialization(ctx, field)
+			case "authors":
+				return ec.fieldContext_Work_authors(ctx, field)
+			case "score":
+				return ec.fieldContext_Work_score(ctx, field)
+			case "ranking":
+				return ec.fieldContext_Work_ranking(ctx, field)
+			case "members":
+				return ec.fieldContext_Work_members(ctx, field)
+			case "favorites":
+				return ec.fieldContext_Work_favorites(ctx, field)
+			case "adaptations":
+				return ec.fieldContext_Work_adaptations(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Work_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Work_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Work", field.Name)
 		},
 	}
 	return fc, nil
@@ -6326,6 +6767,8 @@ func (ec *executionContext) fieldContext_Entity_findAnimeByID(ctx context.Contex
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
 			case "sourceWorkId":
 				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
+			case "sourceWork":
+				return ec.fieldContext_Anime_sourceWork(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -7324,6 +7767,8 @@ func (ec *executionContext) fieldContext_Query_dbSearch(ctx context.Context, fie
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
 			case "sourceWorkId":
 				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
+			case "sourceWork":
+				return ec.fieldContext_Anime_sourceWork(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -7501,6 +7946,8 @@ func (ec *executionContext) fieldContext_Query_anime(ctx context.Context, field 
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
 			case "sourceWorkId":
 				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
+			case "sourceWork":
+				return ec.fieldContext_Anime_sourceWork(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -7625,6 +8072,8 @@ func (ec *executionContext) fieldContext_Query_animeBySlug(ctx context.Context, 
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
 			case "sourceWorkId":
 				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
+			case "sourceWork":
+				return ec.fieldContext_Anime_sourceWork(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -7749,6 +8198,8 @@ func (ec *executionContext) fieldContext_Query_newestAnime(ctx context.Context, 
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
 			case "sourceWorkId":
 				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
+			case "sourceWork":
+				return ec.fieldContext_Anime_sourceWork(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -7873,6 +8324,8 @@ func (ec *executionContext) fieldContext_Query_topRatedAnime(ctx context.Context
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
 			case "sourceWorkId":
 				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
+			case "sourceWork":
+				return ec.fieldContext_Anime_sourceWork(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -7997,6 +8450,8 @@ func (ec *executionContext) fieldContext_Query_mostPopularAnime(ctx context.Cont
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
 			case "sourceWorkId":
 				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
+			case "sourceWork":
+				return ec.fieldContext_Anime_sourceWork(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -8276,6 +8731,8 @@ func (ec *executionContext) fieldContext_Query_currentlyAiring(ctx context.Conte
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
 			case "sourceWorkId":
 				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
+			case "sourceWork":
+				return ec.fieldContext_Anime_sourceWork(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -8400,6 +8857,8 @@ func (ec *executionContext) fieldContext_Query_animeBySeasons(ctx context.Contex
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
 			case "sourceWorkId":
 				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
+			case "sourceWork":
+				return ec.fieldContext_Anime_sourceWork(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -8524,6 +8983,8 @@ func (ec *executionContext) fieldContext_Query_animeBySeasonAndYear(ctx context.
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
 			case "sourceWorkId":
 				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
+			case "sourceWork":
+				return ec.fieldContext_Anime_sourceWork(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -8830,6 +9291,108 @@ func (ec *executionContext) fieldContext_Query_staffBySlug(ctx context.Context, 
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_workBySlug(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_workBySlug(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().WorkBySlug(rctx, fc.Args["slug"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Work)
+	fc.Result = res
+	return ec.marshalOWork2ᚖgithubᚗcomᚋweebᚑvipᚋanimeᚑapiᚋgraphᚋmodelᚐWork(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_workBySlug(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Work_id(ctx, field)
+			case "malId":
+				return ec.fieldContext_Work_malId(ctx, field)
+			case "type":
+				return ec.fieldContext_Work_type(ctx, field)
+			case "urlSlug":
+				return ec.fieldContext_Work_urlSlug(ctx, field)
+			case "titleEn":
+				return ec.fieldContext_Work_titleEn(ctx, field)
+			case "titleJp":
+				return ec.fieldContext_Work_titleJp(ctx, field)
+			case "titleSynonyms":
+				return ec.fieldContext_Work_titleSynonyms(ctx, field)
+			case "synopsis":
+				return ec.fieldContext_Work_synopsis(ctx, field)
+			case "imageUrl":
+				return ec.fieldContext_Work_imageUrl(ctx, field)
+			case "status":
+				return ec.fieldContext_Work_status(ctx, field)
+			case "volumes":
+				return ec.fieldContext_Work_volumes(ctx, field)
+			case "chapters":
+				return ec.fieldContext_Work_chapters(ctx, field)
+			case "publishedFrom":
+				return ec.fieldContext_Work_publishedFrom(ctx, field)
+			case "publishedTo":
+				return ec.fieldContext_Work_publishedTo(ctx, field)
+			case "demographic":
+				return ec.fieldContext_Work_demographic(ctx, field)
+			case "serialization":
+				return ec.fieldContext_Work_serialization(ctx, field)
+			case "authors":
+				return ec.fieldContext_Work_authors(ctx, field)
+			case "score":
+				return ec.fieldContext_Work_score(ctx, field)
+			case "ranking":
+				return ec.fieldContext_Work_ranking(ctx, field)
+			case "members":
+				return ec.fieldContext_Work_members(ctx, field)
+			case "favorites":
+				return ec.fieldContext_Work_favorites(ctx, field)
+			case "adaptations":
+				return ec.fieldContext_Work_adaptations(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Work_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Work_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Work", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_workBySlug_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query__entities(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query__entities(ctx, field)
 	if err != nil {
@@ -9109,6 +9672,8 @@ func (ec *executionContext) fieldContext_RelatedAnime_anime(ctx context.Context,
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
 			case "sourceWorkId":
 				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
+			case "sourceWork":
+				return ec.fieldContext_Anime_sourceWork(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -9346,6 +9911,8 @@ func (ec *executionContext) fieldContext_StaffRole_anime(ctx context.Context, fi
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
 			case "sourceWorkId":
 				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
+			case "sourceWork":
+				return ec.fieldContext_Anime_sourceWork(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -9632,6 +10199,8 @@ func (ec *executionContext) fieldContext_UserAnime_anime(ctx context.Context, fi
 				return ec.fieldContext_Anime_thetvdbid(ctx, field)
 			case "sourceWorkId":
 				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
+			case "sourceWork":
+				return ec.fieldContext_Anime_sourceWork(ctx, field)
 			case "slug":
 				return ec.fieldContext_Anime_slug(ctx, field)
 			case "titleEn":
@@ -9696,6 +10265,1087 @@ func (ec *executionContext) fieldContext_UserAnime_anime(ctx context.Context, fi
 				return ec.fieldContext_Anime_nextEpisode(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Anime", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_id(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_malId(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_malId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.MalID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_malId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_type(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_type(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Type, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_urlSlug(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_urlSlug(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.URLSlug, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_urlSlug(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_titleEn(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_titleEn(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TitleEn, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_titleEn(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_titleJp(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_titleJp(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TitleJp, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_titleJp(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_titleSynonyms(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_titleSynonyms(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TitleSynonyms, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalOString2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_titleSynonyms(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_synopsis(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_synopsis(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Synopsis, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_synopsis(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_imageUrl(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_imageUrl(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ImageURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_imageUrl(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_status(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_status(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Status, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_status(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_volumes(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_volumes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Volumes, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_volumes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_chapters(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_chapters(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Chapters, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_chapters(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_publishedFrom(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_publishedFrom(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PublishedFrom, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_publishedFrom(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_publishedTo(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_publishedTo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PublishedTo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_publishedTo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_demographic(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_demographic(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Demographic, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_demographic(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_serialization(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_serialization(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Serialization, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_serialization(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_authors(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_authors(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Authors, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalOString2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_authors(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_score(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_score(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Score, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*float64)
+	fc.Result = res
+	return ec.marshalOFloat2ᚖfloat64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_score(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_ranking(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_ranking(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Ranking, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_ranking(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_members(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_members(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Members, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_members(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_favorites(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_favorites(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Favorites, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_favorites(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_adaptations(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_adaptations(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Work().Adaptations(rctx, obj, fc.Args["limit"].(*int))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.Anime)
+	fc.Result = res
+	return ec.marshalOAnime2ᚕᚖgithubᚗcomᚋweebᚑvipᚋanimeᚑapiᚋgraphᚋmodelᚐAnimeᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_adaptations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Anime_id(ctx, field)
+			case "anidbid":
+				return ec.fieldContext_Anime_anidbid(ctx, field)
+			case "thetvdbid":
+				return ec.fieldContext_Anime_thetvdbid(ctx, field)
+			case "sourceWorkId":
+				return ec.fieldContext_Anime_sourceWorkId(ctx, field)
+			case "sourceWork":
+				return ec.fieldContext_Anime_sourceWork(ctx, field)
+			case "slug":
+				return ec.fieldContext_Anime_slug(ctx, field)
+			case "titleEn":
+				return ec.fieldContext_Anime_titleEn(ctx, field)
+			case "titleJp":
+				return ec.fieldContext_Anime_titleJp(ctx, field)
+			case "titleRomaji":
+				return ec.fieldContext_Anime_titleRomaji(ctx, field)
+			case "titleKanji":
+				return ec.fieldContext_Anime_titleKanji(ctx, field)
+			case "titleSynonyms":
+				return ec.fieldContext_Anime_titleSynonyms(ctx, field)
+			case "description":
+				return ec.fieldContext_Anime_description(ctx, field)
+			case "imageUrl":
+				return ec.fieldContext_Anime_imageUrl(ctx, field)
+			case "tags":
+				return ec.fieldContext_Anime_tags(ctx, field)
+			case "studios":
+				return ec.fieldContext_Anime_studios(ctx, field)
+			case "animeStatus":
+				return ec.fieldContext_Anime_animeStatus(ctx, field)
+			case "episodeCount":
+				return ec.fieldContext_Anime_episodeCount(ctx, field)
+			case "episodes":
+				return ec.fieldContext_Anime_episodes(ctx, field)
+			case "duration":
+				return ec.fieldContext_Anime_duration(ctx, field)
+			case "rating":
+				return ec.fieldContext_Anime_rating(ctx, field)
+			case "startDate":
+				return ec.fieldContext_Anime_startDate(ctx, field)
+			case "endDate":
+				return ec.fieldContext_Anime_endDate(ctx, field)
+			case "broadcast":
+				return ec.fieldContext_Anime_broadcast(ctx, field)
+			case "source":
+				return ec.fieldContext_Anime_source(ctx, field)
+			case "licensors":
+				return ec.fieldContext_Anime_licensors(ctx, field)
+			case "ranking":
+				return ec.fieldContext_Anime_ranking(ctx, field)
+			case "malId":
+				return ec.fieldContext_Anime_malId(ctx, field)
+			case "scheduleInfo":
+				return ec.fieldContext_Anime_scheduleInfo(ctx, field)
+			case "streamingPlatforms":
+				return ec.fieldContext_Anime_streamingPlatforms(ctx, field)
+			case "fanart":
+				return ec.fieldContext_Anime_fanart(ctx, field)
+			case "seasons":
+				return ec.fieldContext_Anime_seasons(ctx, field)
+			case "type":
+				return ec.fieldContext_Anime_type(ctx, field)
+			case "relatedAnime":
+				return ec.fieldContext_Anime_relatedAnime(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Anime_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Anime_updatedAt(ctx, field)
+			case "nextEpisode":
+				return ec.fieldContext_Anime_nextEpisode(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Anime", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Work_adaptations_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_createdAt(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_createdAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_createdAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Work_updatedAt(ctx context.Context, field graphql.CollectedField, obj *model.Work) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Work_updatedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Work_updatedAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Work",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -11714,6 +13364,39 @@ func (ec *executionContext) _Anime(ctx context.Context, sel ast.SelectionSet, ob
 			out.Values[i] = ec._Anime_thetvdbid(ctx, field, obj)
 		case "sourceWorkId":
 			out.Values[i] = ec._Anime_sourceWorkId(ctx, field, obj)
+		case "sourceWork":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Anime_sourceWork(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "slug":
 			out.Values[i] = ec._Anime_slug(ctx, field, obj)
 		case "titleEn":
@@ -13114,6 +14797,25 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "workBySlug":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_workBySlug(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "_entities":
 			field := field
 
@@ -13369,6 +15071,131 @@ func (ec *executionContext) _UserAnime(ctx context.Context, sel ast.SelectionSet
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var workImplementors = []string{"Work"}
+
+func (ec *executionContext) _Work(ctx context.Context, sel ast.SelectionSet, obj *model.Work) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, workImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Work")
+		case "id":
+			out.Values[i] = ec._Work_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "malId":
+			out.Values[i] = ec._Work_malId(ctx, field, obj)
+		case "type":
+			out.Values[i] = ec._Work_type(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "urlSlug":
+			out.Values[i] = ec._Work_urlSlug(ctx, field, obj)
+		case "titleEn":
+			out.Values[i] = ec._Work_titleEn(ctx, field, obj)
+		case "titleJp":
+			out.Values[i] = ec._Work_titleJp(ctx, field, obj)
+		case "titleSynonyms":
+			out.Values[i] = ec._Work_titleSynonyms(ctx, field, obj)
+		case "synopsis":
+			out.Values[i] = ec._Work_synopsis(ctx, field, obj)
+		case "imageUrl":
+			out.Values[i] = ec._Work_imageUrl(ctx, field, obj)
+		case "status":
+			out.Values[i] = ec._Work_status(ctx, field, obj)
+		case "volumes":
+			out.Values[i] = ec._Work_volumes(ctx, field, obj)
+		case "chapters":
+			out.Values[i] = ec._Work_chapters(ctx, field, obj)
+		case "publishedFrom":
+			out.Values[i] = ec._Work_publishedFrom(ctx, field, obj)
+		case "publishedTo":
+			out.Values[i] = ec._Work_publishedTo(ctx, field, obj)
+		case "demographic":
+			out.Values[i] = ec._Work_demographic(ctx, field, obj)
+		case "serialization":
+			out.Values[i] = ec._Work_serialization(ctx, field, obj)
+		case "authors":
+			out.Values[i] = ec._Work_authors(ctx, field, obj)
+		case "score":
+			out.Values[i] = ec._Work_score(ctx, field, obj)
+		case "ranking":
+			out.Values[i] = ec._Work_ranking(ctx, field, obj)
+		case "members":
+			out.Values[i] = ec._Work_members(ctx, field, obj)
+		case "favorites":
+			out.Values[i] = ec._Work_favorites(ctx, field, obj)
+		case "adaptations":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Work_adaptations(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "createdAt":
+			out.Values[i] = ec._Work_createdAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "updatedAt":
+			out.Values[i] = ec._Work_updatedAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -14840,6 +16667,22 @@ func (ec *executionContext) marshalOFanart2ᚕᚖgithubᚗcomᚋweebᚑvipᚋani
 	return ret
 }
 
+func (ec *executionContext) unmarshalOFloat2ᚖfloat64(ctx context.Context, v interface{}) (*float64, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := graphql.UnmarshalFloatContext(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOFloat2ᚖfloat64(ctx context.Context, sel ast.SelectionSet, v *float64) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	res := graphql.MarshalFloatContext(*v)
+	return graphql.WrapContextMarshaler(ctx, res)
+}
+
 func (ec *executionContext) unmarshalOInt2ᚖint(ctx context.Context, v interface{}) (*int, error) {
 	if v == nil {
 		return nil, nil
@@ -15075,6 +16918,13 @@ func (ec *executionContext) marshalOTime2ᚖtimeᚐTime(ctx context.Context, sel
 	}
 	res := graphql.MarshalTime(*v)
 	return res
+}
+
+func (ec *executionContext) marshalOWork2ᚖgithubᚗcomᚋweebᚑvipᚋanimeᚑapiᚋgraphᚋmodelᚐWork(ctx context.Context, sel ast.SelectionSet, v *model.Work) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._Work(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalO_Entity2githubᚗcomᚋ99designsᚋgqlgenᚋpluginᚋfederationᚋfedruntimeᚐEntity(ctx context.Context, sel ast.SelectionSet, v fedruntime.Entity) graphql.Marshaler {

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -23,6 +23,10 @@ type Anime struct {
 	//
 	// Exposed because relatedAnime resolves SHARED_SOURCE from it.
 	SourceWorkID *string `json:"sourceWorkId,omitempty"`
+	// The work this anime adapts, resolved. Null for originals and for sources
+	// MyAnimeList's manga database does not cover, which together are most of the
+	// catalogue.
+	SourceWork *Work `json:"sourceWork,omitempty"`
 	// Public URL segment for the anime, e.g. "cowboy-bebop". Derived from the
 	// title, with a year and type appended only where several anime would
 	// otherwise claim the same slug. Null for records the backfill has not
@@ -332,6 +336,65 @@ type UserAnime struct {
 }
 
 func (UserAnime) IsEntity() {}
+
+// A source work: the manga, light novel or novel an anime is adapted from.
+//
+// One type for the whole family, discriminated by `type`. MyAnimeList serves them
+// from a single namespace at /manga/<id> and their fields are identical apart from
+// demographic, so splitting them into separate types would mean near-copies and a
+// caller having to guess which to ask for.
+//
+// The public URL follows the same reasoning: /manga/<slug> for all of them, with
+// the type shown on the page. `type` is data that can be corrected upstream, and a
+// URL that moved when a work was reclassified would break every link to it.
+type Work struct {
+	ID string `json:"id"`
+	// MyAnimeList's id for this work. Null for works from any other source.
+	MalID *int `json:"malId,omitempty"`
+	// Which kind of work this is: MANGA, LIGHT_NOVEL, NOVEL, WEB_MANGA,
+	// WEB_NOVEL, ONE_SHOT, DOUJINSHI, MANHWA, MANHUA or FOUR_KOMA.
+	//
+	// A plain string rather than an enum: MyAnimeList adds labels without warning,
+	// and an unrecognised one should render as itself rather than fail the query.
+	Type string `json:"type"`
+	// Public URL segment. Assigned once and never rewritten.
+	URLSlug       *string  `json:"urlSlug,omitempty"`
+	TitleEn       *string  `json:"titleEn,omitempty"`
+	TitleJp       *string  `json:"titleJp,omitempty"`
+	TitleSynonyms []string `json:"titleSynonyms,omitempty"`
+	Synopsis      *string  `json:"synopsis,omitempty"`
+	ImageURL      *string  `json:"imageUrl,omitempty"`
+	// Publication status as the source reports it.
+	Status        *string `json:"status,omitempty"`
+	Volumes       *int    `json:"volumes,omitempty"`
+	Chapters      *int    `json:"chapters,omitempty"`
+	PublishedFrom *string `json:"publishedFrom,omitempty"`
+	PublishedTo   *string `json:"publishedTo,omitempty"`
+	// Target readership -- Shounen, Seinen, Josei. Absent on light novels.
+	Demographic *string `json:"demographic,omitempty"`
+	// The magazine it ran in, when it ran in one.
+	Serialization *string `json:"serialization,omitempty"`
+	// Credited authors, surname first as the source writes them.
+	Authors   []string `json:"authors,omitempty"`
+	Score     *float64 `json:"score,omitempty"`
+	Ranking   *int     `json:"ranking,omitempty"`
+	Members   *int     `json:"members,omitempty"`
+	Favorites *int     `json:"favorites,omitempty"`
+	// Every anime adapted from this work, oldest first.
+	//
+	// This is the point of modelling works at all: Fruits Basket in 2001 and 2019,
+	// Hunter x Hunter in 1999 and 2011. Those share no TheTVDB series id and often
+	// no cast, so nothing else relates them to each other.
+	//
+	// Usually empty, and increasingly so. MyAnimeList holds over sixty thousand
+	// manga against roughly ten thousand anime adapted from one, so most works
+	// have never been adapted and never will be. Empty is the ordinary case here,
+	// not a missing relation -- a page rendering this needs a real empty state
+	// rather than an apology.
+	Adaptations []*Anime `json:"adaptations,omitempty"`
+	CreatedAt   string   `json:"createdAt"`
+	UpdatedAt   string   `json:"updatedAt"`
+}
 
 // Air type for schedule times (raw Japanese broadcast, subtitled, dubbed)
 type AirType string

--- a/graph/resolver.go
+++ b/graph/resolver.go
@@ -14,9 +14,10 @@ import (
 	"github.com/weeb-vip/anime-api/internal/services/anime"
 	"github.com/weeb-vip/anime-api/internal/services/anime_character"
 	anime_character_staff_link2 "github.com/weeb-vip/anime-api/internal/services/anime_character_staff_link"
-	"github.com/weeb-vip/anime-api/internal/services/anime_staff"
 	"github.com/weeb-vip/anime-api/internal/services/anime_season"
+	"github.com/weeb-vip/anime-api/internal/services/anime_staff"
 	"github.com/weeb-vip/anime-api/internal/services/episodes"
+	"github.com/weeb-vip/anime-api/internal/services/work"
 )
 
 // This file will not be regenerated automatically.
@@ -39,6 +40,7 @@ type Resolver struct {
 	AnimeCharacterWithStaffLinkService anime_character_staff_link2.AnimeCharacterStaffLinkImpl
 	AnimeStaffService                  anime_staff.AnimeStaffServiceImpl
 	AnimeSeasonService                 anime_season.AnimeSeasonServiceImpl
+	WorkService                        work.WorkServiceImpl
 	AnimeTagRepository                 anime_tag.AnimeTagRepositoryImpl
 	AnimeScheduleRepository            anime_schedule.AnimeScheduleRepositoryImpl
 	AnimeStreamingPlatformRepository   anime_streaming_platform.AnimeStreamingPlatformRepositoryImpl

--- a/graph/schema.graphqls
+++ b/graph/schema.graphqls
@@ -35,4 +35,13 @@ type Query {
     staff(id: ID!): AnimeStaff
     "Look a staff member up by their public URL slug. Null when no one claims it."
     staffBySlug(slug: String!): AnimeStaff
+    """
+    Look a source work up by its public URL slug -- the manga, light novel or
+    novel behind /manga/<slug>. Null when no work claims it.
+
+    One query for the whole family rather than one per type, because they are
+    one table discriminated by `type`, exactly as MyAnimeList serves them from
+    a single namespace.
+    """
+    workBySlug(slug: String!): Work
 }

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -88,6 +88,11 @@ func (r *queryResolver) StaffBySlug(ctx context.Context, slug string) (*model.An
 	return resolvers.StaffBySlug(ctx, r.AnimeStaffService, slug)
 }
 
+// WorkBySlug is the resolver for the workBySlug field.
+func (r *queryResolver) WorkBySlug(ctx context.Context, slug string) (*model.Work, error) {
+	return resolvers.WorkBySlug(ctx, r.WorkService, slug)
+}
+
 // Query returns generated.QueryResolver implementation.
 func (r *Resolver) Query() generated.QueryResolver { return &queryResolver{r} }
 

--- a/graph/types.graphqls
+++ b/graph/types.graphqls
@@ -89,6 +89,13 @@ type Anime @key(fields: "id") {
     Exposed because relatedAnime resolves SHARED_SOURCE from it.
     """
     sourceWorkId: String
+
+    """
+    The work this anime adapts, resolved. Null for originals and for sources
+    MyAnimeList's manga database does not cover, which together are most of the
+    catalogue.
+    """
+    sourceWork: Work @goField(forceResolver: true)
     """
     Public URL segment for the anime, e.g. "cowboy-bebop". Derived from the
     title, with a year and type appended only where several anime would
@@ -169,6 +176,82 @@ type Anime @key(fields: "id") {
     createdAt: String!
     updatedAt: String!
     nextEpisode: Episode @goField(forceResolver: true )
+}
+
+"""
+A source work: the manga, light novel or novel an anime is adapted from.
+
+One type for the whole family, discriminated by `type`. MyAnimeList serves them
+from a single namespace at /manga/<id> and their fields are identical apart from
+demographic, so splitting them into separate types would mean near-copies and a
+caller having to guess which to ask for.
+
+The public URL follows the same reasoning: /manga/<slug> for all of them, with
+the type shown on the page. `type` is data that can be corrected upstream, and a
+URL that moved when a work was reclassified would break every link to it.
+"""
+type Work {
+    id: ID!
+
+    "MyAnimeList's id for this work. Null for works from any other source."
+    malId: Int
+
+    """
+    Which kind of work this is: MANGA, LIGHT_NOVEL, NOVEL, WEB_MANGA,
+    WEB_NOVEL, ONE_SHOT, DOUJINSHI, MANHWA, MANHUA or FOUR_KOMA.
+
+    A plain string rather than an enum: MyAnimeList adds labels without warning,
+    and an unrecognised one should render as itself rather than fail the query.
+    """
+    type: String!
+
+    "Public URL segment. Assigned once and never rewritten."
+    urlSlug: String
+
+    titleEn: String
+    titleJp: String
+    titleSynonyms: [String!]
+    synopsis: String
+    imageUrl: String
+
+    "Publication status as the source reports it."
+    status: String
+    volumes: Int
+    chapters: Int
+    publishedFrom: String
+    publishedTo: String
+
+    "Target readership -- Shounen, Seinen, Josei. Absent on light novels."
+    demographic: String
+
+    "The magazine it ran in, when it ran in one."
+    serialization: String
+
+    "Credited authors, surname first as the source writes them."
+    authors: [String!]
+
+    score: Float
+    ranking: Int
+    members: Int
+    favorites: Int
+
+    """
+    Every anime adapted from this work, oldest first.
+
+    This is the point of modelling works at all: Fruits Basket in 2001 and 2019,
+    Hunter x Hunter in 1999 and 2011. Those share no TheTVDB series id and often
+    no cast, so nothing else relates them to each other.
+
+    Usually empty, and increasingly so. MyAnimeList holds over sixty thousand
+    manga against roughly ten thousand anime adapted from one, so most works
+    have never been adapted and never will be. Empty is the ordinary case here,
+    not a missing relation -- a page rendering this needs a real empty state
+    rather than an apology.
+    """
+    adaptations(limit: Int): [Anime!] @goField(forceResolver: true)
+
+    createdAt: String!
+    updatedAt: String!
 }
 
 """

--- a/graph/types.resolvers.go
+++ b/graph/types.resolvers.go
@@ -14,6 +14,11 @@ import (
 	"github.com/weeb-vip/anime-api/internal/resolvers"
 )
 
+// SourceWork is the resolver for the sourceWork field.
+func (r *animeResolver) SourceWork(ctx context.Context, obj *model.Anime) (*model.Work, error) {
+	return resolvers.SourceWorkForAnime(ctx, r.WorkService, obj)
+}
+
 // Tags is the resolver for the tags field.
 func (r *animeResolver) Tags(ctx context.Context, obj *model.Anime) ([]string, error) {
 	// Check if tags are already preloaded
@@ -182,6 +187,11 @@ func (r *userAnimeResolver) Anime(ctx context.Context, obj *model.UserAnime) (*m
 	return resolvers.AnimeByID(ctx, r.AnimeService, animeID)
 }
 
+// Adaptations is the resolver for the adaptations field.
+func (r *workResolver) Adaptations(ctx context.Context, obj *model.Work, limit *int) ([]*model.Anime, error) {
+	return resolvers.AdaptationsForWork(ctx, r.AnimeService, obj, limit)
+}
+
 // Anime returns generated.AnimeResolver implementation.
 func (r *Resolver) Anime() generated.AnimeResolver { return &animeResolver{r} }
 
@@ -197,11 +207,15 @@ func (r *Resolver) Episode() generated.EpisodeResolver { return &episodeResolver
 // UserAnime returns generated.UserAnimeResolver implementation.
 func (r *Resolver) UserAnime() generated.UserAnimeResolver { return &userAnimeResolver{r} }
 
+// Work returns generated.WorkResolver implementation.
+func (r *Resolver) Work() generated.WorkResolver { return &workResolver{r} }
+
 type animeResolver struct{ *Resolver }
 type animeStaffResolver struct{ *Resolver }
 type apiInfoResolver struct{ *Resolver }
 type episodeResolver struct{ *Resolver }
 type userAnimeResolver struct{ *Resolver }
+type workResolver struct{ *Resolver }
 
 // !!! WARNING !!!
 // The code below was going to be deleted when updating resolvers. It has been copied here so you have

--- a/http/handlers/root_handler.go
+++ b/http/handlers/root_handler.go
@@ -14,22 +14,24 @@ import (
 	anime2 "github.com/weeb-vip/anime-api/internal/db/repositories/anime"
 	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_character"
 	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_character_staff_link"
-	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_staff"
 	anime3 "github.com/weeb-vip/anime-api/internal/db/repositories/anime_episode"
-	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_schedule"
 	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_fanart"
+	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_schedule"
 	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_season"
+	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_staff"
 	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_streaming_platform"
 	"github.com/weeb-vip/anime-api/internal/db/repositories/anime_tag"
 	"github.com/weeb-vip/anime-api/internal/db/repositories/episode_air_time"
+	workrepo "github.com/weeb-vip/anime-api/internal/db/repositories/work"
 	"github.com/weeb-vip/anime-api/internal/directives"
 	"github.com/weeb-vip/anime-api/internal/logger"
 	"github.com/weeb-vip/anime-api/internal/services/anime"
 	anime_character2 "github.com/weeb-vip/anime-api/internal/services/anime_character"
 	anime_character_staff_link2 "github.com/weeb-vip/anime-api/internal/services/anime_character_staff_link"
-	anime_staff2 "github.com/weeb-vip/anime-api/internal/services/anime_staff"
 	anime_season_service "github.com/weeb-vip/anime-api/internal/services/anime_season"
+	anime_staff2 "github.com/weeb-vip/anime-api/internal/services/anime_staff"
 	"github.com/weeb-vip/anime-api/internal/services/episodes"
+	workservice "github.com/weeb-vip/anime-api/internal/services/work"
 )
 
 func BuildRootHandler(conf config.Config) http.Handler {
@@ -90,6 +92,7 @@ func BuildRootHandler(conf config.Config) http.Handler {
 	animeStreamingPlatformRepository := anime_streaming_platform.NewAnimeStreamingPlatformRepository(database)
 	animeFanartRepository := anime_fanart.NewAnimeFanartRepository(database)
 	episodeAirTimeRepository := episode_air_time.NewEpisodeAirTimeRepository(database)
+	workService := workservice.NewWorkService(workrepo.NewWorkRepository(database))
 	resolvers := &graph.Resolver{
 		Config:                             conf,
 		AnimeService:                       animeService,
@@ -103,6 +106,7 @@ func BuildRootHandler(conf config.Config) http.Handler {
 		AnimeStreamingPlatformRepository:   animeStreamingPlatformRepository,
 		AnimeFanartRepository:              animeFanartRepository,
 		EpisodeAirTimeRepository:           episodeAirTimeRepository,
+		WorkService:                        workService,
 	}
 
 	cfg := generated.Config{Resolvers: resolvers, Directives: directives.GetDirectives()}
@@ -163,6 +167,7 @@ func BuildRootHandlerWithContext(ctx context.Context, conf config.Config) http.H
 	animeStreamingPlatformRepository := anime_streaming_platform.NewAnimeStreamingPlatformRepository(database)
 	animeFanartRepository := anime_fanart.NewAnimeFanartRepository(database)
 	episodeAirTimeRepository := episode_air_time.NewEpisodeAirTimeRepository(database)
+	workService := workservice.NewWorkService(workrepo.NewWorkRepository(database))
 	resolvers := &graph.Resolver{
 		Config:                             conf,
 		AnimeService:                       animeService,
@@ -176,6 +181,7 @@ func BuildRootHandlerWithContext(ctx context.Context, conf config.Config) http.H
 		AnimeStreamingPlatformRepository:   animeStreamingPlatformRepository,
 		AnimeFanartRepository:              animeFanartRepository,
 		EpisodeAirTimeRepository:           episodeAirTimeRepository,
+		WorkService:                        workService,
 		CacheService:                       cacheService,
 		Context:                            ctx,
 	}

--- a/internal/db/repositories/work/work_entity.go
+++ b/internal/db/repositories/work/work_entity.go
@@ -1,0 +1,43 @@
+package work
+
+import "time"
+
+// Work is a manga, light novel, novel, manhwa or manhua -- the source an anime
+// is adapted from.
+//
+// One table for the whole family, discriminated by Type, because MyAnimeList
+// serves them from one namespace and their fields are identical apart from
+// Demographic. The public URL follows the same decision: /manga/<slug> for all
+// of them, with the type shown on the page rather than in the path, since the
+// type is data that can be corrected and a slug must not move.
+type Work struct {
+	ID      string  `gorm:"column:id;primaryKey" json:"id"`
+	MalID   *int    `gorm:"column:mal_id;null" json:"mal_id"`
+	Type    string  `gorm:"column:type" json:"type"`
+	UrlSlug *string `gorm:"column:url_slug;null" json:"url_slug"`
+
+	TitleEn       *string  `gorm:"column:title_en;null" json:"title_en"`
+	TitleJp       *string  `gorm:"column:title_jp;null" json:"title_jp"`
+	TitleSynonyms *string  `gorm:"column:title_synonyms;type:text;null" json:"title_synonyms"`
+	Synopsis      *string  `gorm:"column:synopsis;type:text;null" json:"synopsis"`
+	ImageURL      *string  `gorm:"column:image_url;null" json:"image_url"`
+	Status        *string  `gorm:"column:status;null" json:"status"`
+	Volumes       *int     `gorm:"column:volumes;null" json:"volumes"`
+	Chapters      *int     `gorm:"column:chapters;null" json:"chapters"`
+	PublishedFrom *string  `gorm:"column:published_from;null" json:"published_from"`
+	PublishedTo   *string  `gorm:"column:published_to;null" json:"published_to"`
+	Demographic   *string  `gorm:"column:demographic;null" json:"demographic"`
+	Serialization *string  `gorm:"column:serialization;null" json:"serialization"`
+	Authors       *string  `gorm:"column:authors;type:text;null" json:"authors"`
+	Score         *float64 `gorm:"column:score;null" json:"score"`
+	Ranking       *int     `gorm:"column:ranking;null" json:"ranking"`
+	Members       *int     `gorm:"column:members;null" json:"members"`
+	Favorites     *int     `gorm:"column:favorites;null" json:"favorites"`
+
+	CreatedAt time.Time `gorm:"column:created_at" json:"created_at"`
+	UpdatedAt time.Time `gorm:"column:updated_at" json:"updated_at"`
+}
+
+func (Work) TableName() string {
+	return "work"
+}

--- a/internal/db/repositories/work/work_repository.go
+++ b/internal/db/repositories/work/work_repository.go
@@ -1,0 +1,86 @@
+package work
+
+import (
+	"context"
+	"time"
+
+	"github.com/weeb-vip/anime-api/internal/db"
+	"github.com/weeb-vip/anime-api/metrics"
+)
+
+type WorkRepositoryImpl interface {
+	FindByID(ctx context.Context, id string) (*Work, error)
+	FindBySlug(ctx context.Context, slug string) (*Work, error)
+	FindByIDs(ctx context.Context, ids []string) ([]*Work, error)
+}
+
+type WorkRepository struct {
+	db *db.DB
+}
+
+func NewWorkRepository(db *db.DB) WorkRepositoryImpl {
+	return &WorkRepository{db: db}
+}
+
+func (r *WorkRepository) FindByID(ctx context.Context, id string) (*Work, error) {
+	startTime := time.Now()
+
+	if id == "" {
+		return nil, nil
+	}
+
+	var found Work
+	err := r.db.DB.WithContext(ctx).Where("id = ?", id).First(&found).Error
+	if err != nil {
+		metrics.GetAppMetrics().DatabaseSince(startTime, "work", metrics.MethodSelect, metrics.Error)
+		return nil, err
+	}
+
+	metrics.GetAppMetrics().DatabaseSince(startTime, "work", metrics.MethodSelect, metrics.Success)
+	return &found, nil
+}
+
+// FindBySlug backs /manga/<slug>. Served by idx_work_url_slug from migration
+// 000064.
+//
+// The empty-string guard matters for the same reason it does on the anime
+// relations: url_slug is nullable while the scraper catches up, and ” = ” is
+// true, so a blank slug would match every other blank one and return an
+// arbitrary work.
+func (r *WorkRepository) FindBySlug(ctx context.Context, slug string) (*Work, error) {
+	startTime := time.Now()
+
+	if slug == "" {
+		return nil, nil
+	}
+
+	var found Work
+	err := r.db.DB.WithContext(ctx).Where("url_slug = ?", slug).First(&found).Error
+	if err != nil {
+		metrics.GetAppMetrics().DatabaseSince(startTime, "work", metrics.MethodSelect, metrics.Error)
+		return nil, err
+	}
+
+	metrics.GetAppMetrics().DatabaseSince(startTime, "work", metrics.MethodSelect, metrics.Success)
+	return &found, nil
+}
+
+// FindByIDs exists so a list of anime can resolve its source works in one
+// query rather than one per row.
+func (r *WorkRepository) FindByIDs(ctx context.Context, ids []string) ([]*Work, error) {
+	startTime := time.Now()
+
+	if len(ids) == 0 {
+		return []*Work{}, nil
+	}
+
+	var found []*Work
+	err := r.db.DB.WithContext(ctx).Where("id IN ?", ids).Find(&found).Error
+	if err != nil {
+		metrics.GetAppMetrics().DatabaseSince(startTime, "work", metrics.MethodSelect, metrics.Error)
+		return nil, err
+	}
+
+	metrics.GetAppMetrics().DatabaseSince(startTime, "work", metrics.MethodSelect, metrics.Success)
+	return found, nil
+}

--- a/internal/resolvers/work.go
+++ b/internal/resolvers/work.go
@@ -1,0 +1,170 @@
+package resolvers
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/weeb-vip/anime-api/graph/model"
+	workrepo "github.com/weeb-vip/anime-api/internal/db/repositories/work"
+	"github.com/weeb-vip/anime-api/internal/services/anime"
+	"github.com/weeb-vip/anime-api/internal/services/work"
+	"github.com/weeb-vip/anime-api/tracing"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// jsonList decodes the JSON-in-a-text-column the scraper writes for authors and
+// title synonyms.
+//
+// Returns nil rather than an error on anything unparseable. These columns are
+// scraped, and one malformed row should cost that row its author list, not the
+// whole query -- the same reasoning the scraper's own transformer uses.
+func jsonList(raw *string) []string {
+	if raw == nil || *raw == "" {
+		return nil
+	}
+	var out []string
+	if err := json.Unmarshal([]byte(*raw), &out); err != nil {
+		return nil
+	}
+
+	return out
+}
+
+func transformWorkToGraphQL(w workrepo.Work) *model.Work {
+	return &model.Work{
+		ID:            w.ID,
+		MalID:         w.MalID,
+		Type:          w.Type,
+		URLSlug:       w.UrlSlug,
+		TitleEn:       w.TitleEn,
+		TitleJp:       w.TitleJp,
+		TitleSynonyms: jsonList(w.TitleSynonyms),
+		Synopsis:      w.Synopsis,
+		ImageURL:      w.ImageURL,
+		Status:        w.Status,
+		Volumes:       w.Volumes,
+		Chapters:      w.Chapters,
+		PublishedFrom: w.PublishedFrom,
+		PublishedTo:   w.PublishedTo,
+		Demographic:   w.Demographic,
+		Serialization: w.Serialization,
+		Authors:       jsonList(w.Authors),
+		Score:         w.Score,
+		Ranking:       w.Ranking,
+		Members:       w.Members,
+		Favorites:     w.Favorites,
+		CreatedAt:     w.CreatedAt.String(),
+		UpdatedAt:     w.UpdatedAt.String(),
+	}
+}
+
+// WorkBySlug backs /manga/<slug>.
+//
+// Null for an unknown slug rather than an error: that is a 404 for the page
+// above, not a failure.
+func WorkBySlug(ctx context.Context, workService work.WorkServiceImpl, slug string) (*model.Work, error) {
+	tracer := tracing.GetTracer(ctx)
+	ctx, span := tracer.Start(ctx, "WorkBySlug",
+		trace.WithAttributes(
+			attribute.String("work.slug", slug),
+			attribute.String("resolver.name", "WorkBySlug"),
+		),
+		tracing.GetEnvironmentAttribute(),
+	)
+	defer span.End()
+
+	found, err := workService.FindBySlug(ctx, slug)
+	if err != nil {
+		span.RecordError(err)
+		return nil, err
+	}
+	if found == nil {
+		span.SetAttributes(attribute.Bool("work.found", false))
+		return nil, nil
+	}
+
+	return transformWorkToGraphQL(*found), nil
+}
+
+// SourceWorkForAnime resolves Anime.sourceWork.
+//
+// Null is the ordinary answer. Two thirds of the catalogue is either original
+// or adapted from something MyAnimeList's manga database does not cover, and a
+// work that has not been scraped yet resolves to nothing until it is.
+func SourceWorkForAnime(ctx context.Context, workService work.WorkServiceImpl, obj *model.Anime) (*model.Work, error) {
+	tracer := tracing.GetTracer(ctx)
+	ctx, span := tracer.Start(ctx, "SourceWorkForAnime",
+		trace.WithAttributes(
+			attribute.String("anime.id", obj.ID),
+			attribute.String("resolver.name", "SourceWorkForAnime"),
+		),
+		tracing.GetEnvironmentAttribute(),
+	)
+	defer span.End()
+
+	if obj.SourceWorkID == nil || *obj.SourceWorkID == "" {
+		span.SetAttributes(attribute.Bool("anime.has_source_work", false))
+		return nil, nil
+	}
+
+	found, err := workService.FindByID(ctx, *obj.SourceWorkID)
+	if err != nil {
+		span.RecordError(err)
+		return nil, err
+	}
+	if found == nil {
+		// The anime points at a work the read store has not received yet. Not
+		// an error: CDC makes no ordering promise across tables.
+		span.SetAttributes(attribute.Bool("work.found", false))
+		return nil, nil
+	}
+
+	return transformWorkToGraphQL(*found), nil
+}
+
+// AdaptationsForWork resolves Work.adaptations: every anime adapted from it.
+//
+// Usually empty, and that is the expected answer rather than a gap. MyAnimeList
+// holds far more manga than there are anime adapted from one, so most works
+// have never been adapted.
+func AdaptationsForWork(ctx context.Context, animeService anime.AnimeServiceImpl, obj *model.Work, limit *int) ([]*model.Anime, error) {
+	tracer := tracing.GetTracer(ctx)
+	ctx, span := tracer.Start(ctx, "AdaptationsForWork",
+		trace.WithAttributes(
+			attribute.String("work.id", obj.ID),
+			attribute.String("resolver.name", "AdaptationsForWork"),
+		),
+		tracing.GetEnvironmentAttribute(),
+	)
+	defer span.End()
+
+	resultLimit := 25
+	if limit != nil && *limit > 0 {
+		resultLimit = *limit
+	}
+
+	// The same query the SHARED_SOURCE relation uses, with no anime to exclude
+	// because here the work is the subject rather than one of its adaptations.
+	found, err := animeService.RelatedAnimeBySourceWorkID(ctx, obj.ID, "", resultLimit)
+	if err != nil {
+		span.RecordError(err)
+		return nil, err
+	}
+
+	adaptations := make([]*model.Anime, 0, len(found))
+	for _, entity := range found {
+		if entity == nil {
+			continue
+		}
+		transformed, err := transformAnimeToGraphQL(*entity)
+		if err != nil {
+			span.RecordError(err)
+			return nil, err
+		}
+		adaptations = append(adaptations, transformed)
+	}
+
+	span.SetAttributes(attribute.Int("work.adaptation_count", len(adaptations)))
+	return adaptations, nil
+}

--- a/internal/services/work/work_service.go
+++ b/internal/services/work/work_service.go
@@ -1,0 +1,72 @@
+package work
+
+import (
+	"context"
+	"errors"
+
+	"gorm.io/gorm"
+
+	workrepo "github.com/weeb-vip/anime-api/internal/db/repositories/work"
+	"github.com/weeb-vip/anime-api/tracing"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+type WorkServiceImpl interface {
+	FindByID(ctx context.Context, id string) (*workrepo.Work, error)
+	FindBySlug(ctx context.Context, slug string) (*workrepo.Work, error)
+	FindByIDs(ctx context.Context, ids []string) ([]*workrepo.Work, error)
+}
+
+type WorkService struct {
+	Repository workrepo.WorkRepositoryImpl
+}
+
+func NewWorkService(repository workrepo.WorkRepositoryImpl) WorkServiceImpl {
+	return &WorkService{Repository: repository}
+}
+
+// notFoundToNil turns "no such row" into a null result rather than an error.
+//
+// A slug that does not resolve is an ordinary 404 for the page above, not a
+// failure worth an error in the response and a span marked bad. Every other
+// database error still propagates.
+func notFoundToNil(w *workrepo.Work, err error) (*workrepo.Work, error) {
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return w, nil
+}
+
+func (s *WorkService) FindByID(ctx context.Context, id string) (*workrepo.Work, error) {
+	span, spanCtx := tracer.StartSpanFromContext(ctx, "FindByID")
+	span.SetTag("service", "work")
+	span.SetTag("type", "service")
+	span.SetTag("environment", tracing.GetEnvironmentTag())
+	defer span.Finish()
+
+	return notFoundToNil(s.Repository.FindByID(spanCtx, id))
+}
+
+func (s *WorkService) FindBySlug(ctx context.Context, slug string) (*workrepo.Work, error) {
+	span, spanCtx := tracer.StartSpanFromContext(ctx, "FindBySlug")
+	span.SetTag("service", "work")
+	span.SetTag("type", "service")
+	span.SetTag("environment", tracing.GetEnvironmentTag())
+	defer span.Finish()
+
+	return notFoundToNil(s.Repository.FindBySlug(spanCtx, slug))
+}
+
+func (s *WorkService) FindByIDs(ctx context.Context, ids []string) ([]*workrepo.Work, error) {
+	span, spanCtx := tracer.StartSpanFromContext(ctx, "FindByIDs")
+	span.SetTag("service", "work")
+	span.SetTag("type", "service")
+	span.SetTag("environment", tracing.GetEnvironmentTag())
+	defer span.Finish()
+
+	return s.Repository.FindByIDs(spanCtx, ids)
+}


### PR DESCRIPTION
The read store has held works since anime-sync #27 landed and nothing could ask for them. This is what `/manga/<slug>` will query.

## What it adds

| | |
|---|---|
| `workBySlug(slug: String!): Work` | backs `/manga/<slug>`; follows `animeBySlug`/`staffBySlug`, **null** for an unknown slug rather than an error — a 404 for the page above, not a failure |
| `Anime.sourceWork: Work` | resolves the column added in #67 |
| `Work.adaptations(limit): [Anime!]` | the reverse — every anime adapted from a work |

`Work.adaptations` is the point of modelling works at all: Fruits Basket 2001 and 2019 share no TheTVDB id and no cast, so nothing else relates them. It reuses `FindBySourceWorkID` from #67 with no anime excluded.

## Decisions worth reviewing

**One `Work` type, not one per kind.** They are one table discriminated by `type` because MAL serves them from a single namespace and their fields are identical apart from `demographic`. Three near-identical types would just make callers guess which to ask for.

**`type` is a plain `String!`, not an enum.** MyAnimeList adds labels without warning; an unfamiliar one should render as itself rather than fail the whole query.

**`adaptations` is documented as usually empty.** MAL holds 60,000+ manga against roughly 10,000 anime adapted from one, so most works have never been adapted — and once `collect manga` runs, the empty case becomes the overwhelming majority. The schema says this explicitly so a page renders a real empty state rather than treating it as a gap.

## Verified

`go build ./...` clean, gqlgen regenerated cleanly, `gofmt -l` clean on every file I touched.

`go vet` still reports the two pre-existing failures in `air_time_test.go` and `anime_season_optimized_test.go` — same as #67, confirmed on `main`, caused by an already-incomplete `MockAnimeService`.

End-to-end verification happens after deploy: there are 12 works in the read store right now (`/manga/hellsing`, `/manga/land-of-the-lustrous`, `/manga/march-comes-in-like-a-lion` …), so `workBySlug` has real data to return immediately.

## Next

The frontend route. `Anime.sourceWork` will stay null on every anime until backfill pass 3 runs — `anime with source_work_id` is currently 0.